### PR TITLE
implement DynamoDB table initialization script and schema tests

### DIFF
--- a/backend/src/infrastructure/init-dynamodb.ts
+++ b/backend/src/infrastructure/init-dynamodb.ts
@@ -1,0 +1,288 @@
+/**
+ * DynamoDB Table Initialization Script
+ * 
+ * This script creates the VetPetRegistry table with all required Global Secondary Indexes.
+ * It supports both LocalStack (local development) and AWS (cloud deployment) environments.
+ */
+
+import {
+  DynamoDBClient,
+  CreateTableCommand,
+  DescribeTableCommand,
+  DeleteTableCommand,
+  waitUntilTableExists,
+  waitUntilTableNotExists,
+} from '@aws-sdk/client-dynamodb'
+import { AWSClientFactory } from './aws-client-factory'
+
+export interface TableConfig {
+  tableName: string
+  billingMode?: 'PAY_PER_REQUEST' | 'PROVISIONED'
+  readCapacity?: number
+  writeCapacity?: number
+}
+
+export class DynamoDBTableInitializer {
+  private client: DynamoDBClient
+  private tableName: string
+
+  constructor(tableName: string = 'VetPetRegistry') {
+    const factory = new AWSClientFactory()
+    this.client = factory.createDynamoDBClient()
+    this.tableName = tableName
+  }
+
+  /**
+   * Create the VetPetRegistry table with all GSIs
+   */
+  async createTable(config?: TableConfig): Promise<void> {
+    const tableName = config?.tableName || this.tableName
+    const billingMode = config?.billingMode || 'PAY_PER_REQUEST'
+
+    console.log(`Creating DynamoDB table: ${tableName}`)
+
+    const command = new CreateTableCommand({
+      TableName: tableName,
+      BillingMode: billingMode,
+      
+      // Attribute definitions for all keys used in table and GSIs
+      AttributeDefinitions: [
+        { AttributeName: 'PK', AttributeType: 'S' },
+        { AttributeName: 'SK', AttributeType: 'S' },
+        { AttributeName: 'GSI1PK', AttributeType: 'S' },
+        { AttributeName: 'GSI1SK', AttributeType: 'S' },
+        { AttributeName: 'GSI2PK', AttributeType: 'S' },
+        { AttributeName: 'GSI2SK', AttributeType: 'S' },
+        { AttributeName: 'GSI3PK', AttributeType: 'S' },
+        { AttributeName: 'GSI3SK', AttributeType: 'S' },
+        { AttributeName: 'GSI4PK', AttributeType: 'S' },
+        { AttributeName: 'GSI4SK', AttributeType: 'S' },
+        { AttributeName: 'GSI5PK', AttributeType: 'S' },
+        { AttributeName: 'GSI5SK', AttributeType: 'S' },
+      ],
+
+      // Primary key schema
+      KeySchema: [
+        { AttributeName: 'PK', KeyType: 'HASH' },
+        { AttributeName: 'SK', KeyType: 'RANGE' },
+      ],
+
+      // Global Secondary Indexes
+      GlobalSecondaryIndexes: [
+        {
+          // GSI1: License number lookup for clinics
+          IndexName: 'GSI1',
+          KeySchema: [
+            { AttributeName: 'GSI1PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI1SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+          ...(billingMode === 'PROVISIONED' && {
+            ProvisionedThroughput: {
+              ReadCapacityUnits: config?.readCapacity || 5,
+              WriteCapacityUnits: config?.writeCapacity || 5,
+            },
+          }),
+        },
+        {
+          // GSI2: Pet search by species and breed
+          IndexName: 'GSI2',
+          KeySchema: [
+            { AttributeName: 'GSI2PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI2SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+          ...(billingMode === 'PROVISIONED' && {
+            ProvisionedThroughput: {
+              ReadCapacityUnits: config?.readCapacity || 5,
+              WriteCapacityUnits: config?.writeCapacity || 5,
+            },
+          }),
+        },
+        {
+          // GSI3: Owner lookup (only for claimed pets)
+          IndexName: 'GSI3',
+          KeySchema: [
+            { AttributeName: 'GSI3PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI3SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+          ...(billingMode === 'PROVISIONED' && {
+            ProvisionedThroughput: {
+              ReadCapacityUnits: config?.readCapacity || 5,
+              WriteCapacityUnits: config?.writeCapacity || 5,
+            },
+          }),
+        },
+        {
+          // GSI4: Claiming code lookup (only for pending pets)
+          IndexName: 'GSI4',
+          KeySchema: [
+            { AttributeName: 'GSI4PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI4SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+          ...(billingMode === 'PROVISIONED' && {
+            ProvisionedThroughput: {
+              ReadCapacityUnits: config?.readCapacity || 5,
+              WriteCapacityUnits: config?.writeCapacity || 5,
+            },
+          }),
+        },
+        {
+          // GSI5: Care snapshot access code lookup
+          IndexName: 'GSI5',
+          KeySchema: [
+            { AttributeName: 'GSI5PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI5SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+          ...(billingMode === 'PROVISIONED' && {
+            ProvisionedThroughput: {
+              ReadCapacityUnits: config?.readCapacity || 5,
+              WriteCapacityUnits: config?.writeCapacity || 5,
+            },
+          }),
+        },
+      ],
+
+      // Provisioned throughput (only for PROVISIONED billing mode)
+      ...(billingMode === 'PROVISIONED' && {
+        ProvisionedThroughput: {
+          ReadCapacityUnits: config?.readCapacity || 5,
+          WriteCapacityUnits: config?.writeCapacity || 5,
+        },
+      }),
+    })
+
+    try {
+      await this.client.send(command)
+      console.log(`Table ${tableName} creation initiated`)
+
+      // Wait for table to be active
+      await waitUntilTableExists(
+        { client: this.client, maxWaitTime: 60 },
+        { TableName: tableName }
+      )
+
+      console.log(`Table ${tableName} is now active`)
+    } catch (error: any) {
+      if (error.name === 'ResourceInUseException') {
+        console.log(`Table ${tableName} already exists`)
+      } else {
+        console.error(`Error creating table ${tableName}:`, error)
+        throw error
+      }
+    }
+  }
+
+  /**
+   * Delete the VetPetRegistry table
+   * WARNING: This will delete all data in the table
+   */
+  async deleteTable(tableName?: string): Promise<void> {
+    const table = tableName || this.tableName
+    console.log(`Deleting DynamoDB table: ${table}`)
+
+    try {
+      const command = new DeleteTableCommand({ TableName: table })
+      await this.client.send(command)
+      console.log(`Table ${table} deletion initiated`)
+
+      // Wait for table to be deleted
+      await waitUntilTableNotExists(
+        { client: this.client, maxWaitTime: 60 },
+        { TableName: table }
+      )
+
+      console.log(`Table ${table} has been deleted`)
+    } catch (error: any) {
+      if (error.name === 'ResourceNotFoundException') {
+        console.log(`Table ${table} does not exist`)
+      } else {
+        console.error(`Error deleting table ${table}:`, error)
+        throw error
+      }
+    }
+  }
+
+  /**
+   * Check if the table exists
+   */
+  async tableExists(tableName?: string): Promise<boolean> {
+    const table = tableName || this.tableName
+    try {
+      const command = new DescribeTableCommand({ TableName: table })
+      await this.client.send(command)
+      return true
+    } catch (error: any) {
+      if (error.name === 'ResourceNotFoundException') {
+        return false
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Get table description including GSI information
+   */
+  async describeTable(tableName?: string): Promise<any> {
+    const table = tableName || this.tableName
+    const command = new DescribeTableCommand({ TableName: table })
+    const response = await this.client.send(command)
+    return response.Table
+  }
+
+  /**
+   * Initialize table for testing (delete if exists, then create)
+   */
+  async initializeForTesting(config?: TableConfig): Promise<void> {
+    const tableName = config?.tableName || this.tableName
+    
+    if (await this.tableExists(tableName)) {
+      await this.deleteTable(tableName)
+    }
+    
+    await this.createTable(config)
+  }
+}
+
+/**
+ * CLI script to initialize the table
+ * Usage: tsx src/infrastructure/init-dynamodb.ts [create|delete|describe]
+ */
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const command = process.argv[2] || 'create'
+  const tableName = process.env.DYNAMODB_TABLE_NAME || 'VetPetRegistry'
+  
+  const initializer = new DynamoDBTableInitializer(tableName)
+
+  async function main() {
+    try {
+      switch (command) {
+        case 'create':
+          await initializer.createTable()
+          break
+        case 'delete':
+          await initializer.deleteTable()
+          break
+        case 'describe':
+          const description = await initializer.describeTable()
+          console.log(JSON.stringify(description, null, 2))
+          break
+        case 'init-test':
+          await initializer.initializeForTesting()
+          break
+        default:
+          console.error(`Unknown command: ${command}`)
+          console.log('Usage: tsx src/infrastructure/init-dynamodb.ts [create|delete|describe|init-test]')
+          process.exit(1)
+      }
+    } catch (error) {
+      console.error('Error:', error)
+      process.exit(1)
+    }
+  }
+
+  main()
+}

--- a/backend/tests/dynamodb-table-schema.test.ts
+++ b/backend/tests/dynamodb-table-schema.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for DynamoDB table schema initialization
+ * 
+ * These tests verify that the VetPetRegistry table is created correctly
+ * with all required Global Secondary Indexes in LocalStack.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { DynamoDBTableInitializer } from '../src/infrastructure/init-dynamodb'
+import { EnvironmentDetector } from '../src/infrastructure/environment-detector'
+
+describe('DynamoDB Table Schema', () => {
+  let initializer: DynamoDBTableInitializer
+  const testTableName = 'VetPetRegistry-Test'
+
+  beforeAll(async () => {
+    // Ensure we're running in local environment
+    const envDetector = EnvironmentDetector.getInstance()
+    expect(envDetector.isLocal()).toBe(true)
+
+    initializer = new DynamoDBTableInitializer(testTableName)
+    
+    // Clean up any existing test table
+    if (await initializer.tableExists(testTableName)) {
+      await initializer.deleteTable(testTableName)
+    }
+  })
+
+  afterAll(async () => {
+    // Clean up test table
+    try {
+      if (await initializer.tableExists(testTableName)) {
+        await initializer.deleteTable(testTableName)
+      }
+    } catch (error) {
+      console.error('Error cleaning up test table:', error)
+    }
+  })
+
+  it('should create table successfully in LocalStack', async () => {
+    await initializer.createTable({ tableName: testTableName })
+    
+    const exists = await initializer.tableExists(testTableName)
+    expect(exists).toBe(true)
+  })
+
+  it('should have correct primary key schema', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    expect(description).toBeDefined()
+    expect(description.KeySchema).toBeDefined()
+    expect(description.KeySchema).toHaveLength(2)
+    
+    const hashKey = description.KeySchema.find((key: any) => key.KeyType === 'HASH')
+    const rangeKey = description.KeySchema.find((key: any) => key.KeyType === 'RANGE')
+    
+    expect(hashKey).toBeDefined()
+    expect(hashKey.AttributeName).toBe('PK')
+    
+    expect(rangeKey).toBeDefined()
+    expect(rangeKey.AttributeName).toBe('SK')
+  })
+
+  it('should have all required attribute definitions', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    expect(description.AttributeDefinitions).toBeDefined()
+    
+    const attributeNames = description.AttributeDefinitions.map((attr: any) => attr.AttributeName)
+    
+    expect(attributeNames).toContain('PK')
+    expect(attributeNames).toContain('SK')
+    expect(attributeNames).toContain('GSI1PK')
+    expect(attributeNames).toContain('GSI1SK')
+    expect(attributeNames).toContain('GSI2PK')
+    expect(attributeNames).toContain('GSI2SK')
+    expect(attributeNames).toContain('GSI3PK')
+    expect(attributeNames).toContain('GSI3SK')
+    expect(attributeNames).toContain('GSI4PK')
+    expect(attributeNames).toContain('GSI4SK')
+    expect(attributeNames).toContain('GSI5PK')
+    expect(attributeNames).toContain('GSI5SK')
+    
+    // All attributes should be strings
+    description.AttributeDefinitions.forEach((attr: any) => {
+      expect(attr.AttributeType).toBe('S')
+    })
+  })
+
+  it('should have GSI1 configured correctly for license number lookup', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    expect(description.GlobalSecondaryIndexes).toBeDefined()
+    
+    const gsi1 = description.GlobalSecondaryIndexes.find((gsi: any) => gsi.IndexName === 'GSI1')
+    
+    expect(gsi1).toBeDefined()
+    expect(gsi1.KeySchema).toHaveLength(2)
+    
+    const hashKey = gsi1.KeySchema.find((key: any) => key.KeyType === 'HASH')
+    const rangeKey = gsi1.KeySchema.find((key: any) => key.KeyType === 'RANGE')
+    
+    expect(hashKey.AttributeName).toBe('GSI1PK')
+    expect(rangeKey.AttributeName).toBe('GSI1SK')
+    
+    expect(gsi1.Projection.ProjectionType).toBe('ALL')
+  })
+
+  it('should have GSI2 configured correctly for species/breed search', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    const gsi2 = description.GlobalSecondaryIndexes.find((gsi: any) => gsi.IndexName === 'GSI2')
+    
+    expect(gsi2).toBeDefined()
+    expect(gsi2.KeySchema).toHaveLength(2)
+    
+    const hashKey = gsi2.KeySchema.find((key: any) => key.KeyType === 'HASH')
+    const rangeKey = gsi2.KeySchema.find((key: any) => key.KeyType === 'RANGE')
+    
+    expect(hashKey.AttributeName).toBe('GSI2PK')
+    expect(rangeKey.AttributeName).toBe('GSI2SK')
+    
+    expect(gsi2.Projection.ProjectionType).toBe('ALL')
+  })
+
+  it('should have GSI3 configured correctly for owner lookup', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    const gsi3 = description.GlobalSecondaryIndexes.find((gsi: any) => gsi.IndexName === 'GSI3')
+    
+    expect(gsi3).toBeDefined()
+    expect(gsi3.KeySchema).toHaveLength(2)
+    
+    const hashKey = gsi3.KeySchema.find((key: any) => key.KeyType === 'HASH')
+    const rangeKey = gsi3.KeySchema.find((key: any) => key.KeyType === 'RANGE')
+    
+    expect(hashKey.AttributeName).toBe('GSI3PK')
+    expect(rangeKey.AttributeName).toBe('GSI3SK')
+    
+    expect(gsi3.Projection.ProjectionType).toBe('ALL')
+  })
+
+  it('should have exactly 5 Global Secondary Indexes', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    expect(description.GlobalSecondaryIndexes).toHaveLength(5)
+    
+    const indexNames = description.GlobalSecondaryIndexes.map((gsi: any) => gsi.IndexName)
+    expect(indexNames).toContain('GSI1')
+    expect(indexNames).toContain('GSI2')
+    expect(indexNames).toContain('GSI3')
+    expect(indexNames).toContain('GSI4')
+    expect(indexNames).toContain('GSI5')
+  })
+
+  it('should have GSI4 configured correctly for claiming code lookup', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    const gsi4 = description.GlobalSecondaryIndexes.find((gsi: any) => gsi.IndexName === 'GSI4')
+    expect(gsi4).toBeDefined()
+    
+    expect(gsi4.KeySchema).toHaveLength(2)
+    expect(gsi4.KeySchema[0].AttributeName).toBe('GSI4PK')
+    expect(gsi4.KeySchema[0].KeyType).toBe('HASH')
+    expect(gsi4.KeySchema[1].AttributeName).toBe('GSI4SK')
+    expect(gsi4.KeySchema[1].KeyType).toBe('RANGE')
+    
+    expect(gsi4.Projection.ProjectionType).toBe('ALL')
+  })
+
+  it('should have GSI5 configured correctly for care snapshot access', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    const gsi5 = description.GlobalSecondaryIndexes.find((gsi: any) => gsi.IndexName === 'GSI5')
+    expect(gsi5).toBeDefined()
+    
+    expect(gsi5.KeySchema).toHaveLength(2)
+    expect(gsi5.KeySchema[0].AttributeName).toBe('GSI5PK')
+    expect(gsi5.KeySchema[0].KeyType).toBe('HASH')
+    expect(gsi5.KeySchema[1].AttributeName).toBe('GSI5SK')
+    expect(gsi5.KeySchema[1].KeyType).toBe('RANGE')
+    
+    expect(gsi5.Projection.ProjectionType).toBe('ALL')
+  })
+
+  it('should use PAY_PER_REQUEST billing mode by default', async () => {
+    const description = await initializer.describeTable(testTableName)
+    
+    expect(description.BillingModeSummary).toBeDefined()
+    expect(description.BillingModeSummary.BillingMode).toBe('PAY_PER_REQUEST')
+  })
+
+  it('should handle table already exists error gracefully', async () => {
+    // Table already exists from previous test
+    await expect(
+      initializer.createTable({ tableName: testTableName })
+    ).resolves.not.toThrow()
+  })
+
+  it('should return false for non-existent table', async () => {
+    const exists = await initializer.tableExists('NonExistentTable')
+    expect(exists).toBe(false)
+  })
+
+  it('should initialize table for testing (delete and recreate)', async () => {
+    await initializer.initializeForTesting({ tableName: testTableName })
+    
+    const exists = await initializer.tableExists(testTableName)
+    expect(exists).toBe(true)
+    
+    const description = await initializer.describeTable(testTableName)
+    expect(description.TableStatus).toBe('ACTIVE')
+  })
+})


### PR DESCRIPTION
### Description
Resolves #27.

Implemented the `DynamoDBTableInitializer` to automate the creation, teardown, and testing of the `VetPetRegistry` table. The script configures the system's Single-Table Design schema, including the primary `PK`/`SK` keys and all 5 Global Secondary Indexes (GSIs) required for the system's access patterns. Included a full integration test suite that mathematically verifies the schema deployment against LocalStack.

### Definition of Done Checklist:
- [x] Create `init-dynamodb.ts` supporting local/cloud execution
- [x] Define Primary Key (PK/SK) schema
- [x] Configure GSI 1-5 for entity lookups (Clinics, Pets, Owners, Claims, Snapshots)
- [x] Write schema validation tests to prove table creation succeeds in LocalStack

### Requirements Traceability
*Validates Requirements: **[NFR-MNT-01]** (Local environment support)*