### PR TITLE
fix(#38): add updateClaimingCode method to PetRepository

### DIFF
--- a/backend/src/repositories/pet-repository.ts
+++ b/backend/src/repositories/pet-repository.ts
@@ -563,6 +563,26 @@ export class PetRepository {
   }
 
   /**
+   * Update the claiming code and expiry for a pending profile
+   */
+  async updateClaimingCode(petId: string, claimingCode: string, expiryDate: string): Promise<void> {
+    const now = new Date().toISOString()
+    const command = new UpdateCommand({
+      TableName: this.tableName,
+      Key: { PK: `PET#${petId}`, SK: 'METADATA' },
+      UpdateExpression: 'SET claimingCode = :code, claimingCodeExpiry = :expiry, GSI4PK = :gsi4pk, GSI4SK = :gsi4sk, updatedAt = :updatedAt',
+      ExpressionAttributeValues: {
+        ':code': claimingCode,
+        ':expiry': expiryDate,
+        ':gsi4pk': `CLAIM#${claimingCode}`,
+        ':gsi4sk': `PET#${petId}`,
+        ':updatedAt': now,
+      },
+    })
+    await this.docClient.send(command)
+  }
+
+  /**
    * Set the isMissing flag on a pet
    */
   async setMissingStatus(petId: string, isMissing: boolean): Promise<Pet> {


### PR DESCRIPTION
### Description
Fast-follow fix for #38. Added the `updateClaimingCode` method to the `PetRepository`. This provides the necessary DynamoDB UpdateCommand (with GSI4 updates) required by the `ProfileClaimingService` to regenerate claiming codes for unclaimed profiles.