### PR TITLE
fix: pin localstack to 3.8 to avoid license activation requirement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # LocalStack - AWS service emulator for local development
   # Provides local versions of DynamoDB, S3, Lambda, API Gateway, Cognito, SNS, and SES
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:3.8
     container_name: paw-print-profile-localstack
     ports:
       - "4566:4566"  # LocalStack gateway - all AWS services accessible through this port


### PR DESCRIPTION
### Description
Infrastructure hotfix. Pinned the LocalStack Docker image version to `3.8` in `docker-compose.yml`. 

**Reasoning:** The `latest` LocalStack tag recently introduced a breaking change requiring a `LOCALSTACK_AUTH_TOKEN` for license activation, causing the container to crash with exit code 55. Pinning to the stable `3.8` community version ensures a deterministic, reproducible local development environment without unexpected license enforcement.