### PR TITLE
test(#78): add property tests for ErrorHandler

### DIFF
--- a/backend/tests/error-handler.property.test.ts
+++ b/backend/tests/error-handler.property.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Property-based tests for ErrorHandler and custom error classes
+ *
+ * Property 45: Error logging — all errors produce structured JSON log entries
+ * Property 46: API error responses — errors map to correct HTTP status codes
+ * Property 47: Structured logging format — log entries contain required fields
+ *
+ * Validates: Requirements [NFR-OPS-02], [NFR-USA-04]
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import fc from 'fast-check'
+import {
+  AppError,
+  ValidationError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ErrorHandler,
+  ErrorLogEntry,
+} from '../src/errors/index'
+import { ValidationException } from '../src/validation/validators'
+
+// ── Arbitraries ──────────────────────────────────────────────────────────────
+
+/** Arbitrary non-empty message string */
+const messageArb = fc.stringMatching(/^[a-zA-Z0-9 .,!?'-]{1,100}$/)
+
+/** Arbitrary field name for validation details */
+const fieldNameArb = fc.stringMatching(/^[a-zA-Z][a-zA-Z0-9_]{0,29}$/)
+
+/** Arbitrary validation detail entry */
+const validationDetailArb = fc.record({
+  field: fieldNameArb,
+  message: messageArb,
+})
+
+/** Arbitrary non-empty array of validation details */
+const validationDetailsArb = fc.array(validationDetailArb, { minLength: 1, maxLength: 10 })
+
+/** Arbitrary context object for error handler */
+const contextArb = fc.record({
+  handler: fc.stringMatching(/^[a-zA-Z]{1,30}$/),
+  petId: fc.stringMatching(/^[a-zA-Z0-9-]{1,36}$/),
+})
+
+/** Arbitrary CORS headers */
+const corsHeadersArb = fc.constant({
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+})
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Suppress console.error output during tests */
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+/** Create a fake AWS SDK-style error with a specific name */
+function makeNamedError(name: string, message: string = 'aws error'): Error {
+  const err = new Error(message)
+  err.name = name
+  return err
+}
+
+/** Create a legacy ValidationException */
+function makeLegacyValidationException(
+  details: Array<{ field: string; message: string }>
+): ValidationException {
+  return new ValidationException(details)
+}
+
+// ── Property 45: Error logging ───────────────────────────────────────────────
+
+describe('[NFR-OPS-02] Property 45: Error logging', () => {
+  /**
+   * For any AppError subclass, ErrorHandler.handle() emits a structured
+   * JSON string to console.error containing the error code and message.
+   */
+  it('all AppError subclasses produce a structured JSON log line', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        const errors = [
+          new ValidationError(msg),
+          new AuthenticationError(msg),
+          new AuthorizationError(msg),
+          new NotFoundError(msg),
+        ]
+
+        for (const error of errors) {
+          const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+          ErrorHandler.handle(error)
+
+          expect(spy).toHaveBeenCalledOnce()
+          const logLine = spy.mock.calls[0][0] as string
+          const parsed = JSON.parse(logLine)
+
+          expect(parsed.code).toBe(error.code)
+          expect(parsed.message).toBe(msg)
+          spy.mockRestore()
+        }
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * For any generic Error, ErrorHandler.handle() still emits a structured
+   * JSON log line with code INTERNAL_ERROR.
+   */
+  it('generic errors produce a structured JSON log line with INTERNAL_ERROR', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        ErrorHandler.handle(new Error(msg))
+
+        expect(spy).toHaveBeenCalledOnce()
+        const parsed = JSON.parse(spy.mock.calls[0][0] as string)
+        expect(parsed.code).toBe('INTERNAL_ERROR')
+        spy.mockRestore()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * For any non-Error thrown value (string, number, object),
+   * ErrorHandler.handle() still produces a valid log entry.
+   */
+  it('non-Error thrown values produce a valid log entry', () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.string(), fc.integer(), fc.constant(null), fc.constant(undefined)),
+        (thrown) => {
+          const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+          const { logEntry } = ErrorHandler.handle(thrown)
+
+          expect(spy).toHaveBeenCalledOnce()
+          expect(logEntry.code).toBe('INTERNAL_ERROR')
+          expect(logEntry.statusCode).toBe(500)
+          spy.mockRestore()
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * When context is provided, the log entry includes it.
+   * When context is omitted, the log entry does not have a context field.
+   */
+  it('context is included in log entry when provided and absent when omitted', () => {
+    fc.assert(
+      fc.property(messageArb, contextArb, (msg, ctx) => {
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        // With context
+        const { logEntry: withCtx } = ErrorHandler.handle(new Error(msg), ctx)
+        expect(withCtx.context).toEqual(ctx)
+
+        spy.mockRestore()
+        const spy2 = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        // Without context
+        const { logEntry: withoutCtx } = ErrorHandler.handle(new Error(msg))
+        expect(withoutCtx.context).toBeUndefined()
+
+        spy2.mockRestore()
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ── Property 46: API error responses ─────────────────────────────────────────
+
+describe('[NFR-USA-04] Property 46: API error responses', () => {
+  /**
+   * ValidationError always maps to 400.
+   */
+  it('ValidationError maps to HTTP 400', () => {
+    fc.assert(
+      fc.property(messageArb, validationDetailsArb, (msg, details) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { statusCode, body } = ErrorHandler.handle(new ValidationError(msg, details))
+
+        expect(statusCode).toBe(400)
+        expect((body.error as any).code).toBe('VALIDATION_ERROR')
+        expect((body.error as any).details).toEqual(details)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * AuthenticationError always maps to 401.
+   */
+  it('AuthenticationError maps to HTTP 401', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { statusCode, body } = ErrorHandler.handle(new AuthenticationError(msg))
+
+        expect(statusCode).toBe(401)
+        expect((body.error as any).code).toBe('AUTHENTICATION_ERROR')
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * AuthorizationError always maps to 403.
+   */
+  it('AuthorizationError maps to HTTP 403', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { statusCode, body } = ErrorHandler.handle(new AuthorizationError(msg))
+
+        expect(statusCode).toBe(403)
+        expect((body.error as any).code).toBe('AUTHORIZATION_ERROR')
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * NotFoundError always maps to 404.
+   */
+  it('NotFoundError maps to HTTP 404', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { statusCode, body } = ErrorHandler.handle(new NotFoundError(msg))
+
+        expect(statusCode).toBe(404)
+        expect((body.error as any).code).toBe('NOT_FOUND')
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * Legacy ValidationException maps to 400 with details preserved.
+   */
+  it('legacy ValidationException maps to HTTP 400 with details', () => {
+    fc.assert(
+      fc.property(validationDetailsArb, (details) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const exception = makeLegacyValidationException(details)
+        const { statusCode, body } = ErrorHandler.handle(exception)
+
+        expect(statusCode).toBe(400)
+        expect((body.error as any).code).toBe('VALIDATION_ERROR')
+        expect((body.error as any).details).toEqual(details)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * AWS ResourceNotFoundException maps to 404.
+   */
+  it('ResourceNotFoundException maps to HTTP 404', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { statusCode, body } = ErrorHandler.handle(
+      makeNamedError('ResourceNotFoundException')
+    )
+
+    expect(statusCode).toBe(404)
+    expect((body.error as any).code).toBe('NOT_FOUND')
+  })
+
+  /**
+   * AWS ConditionalCheckFailedException maps to 409.
+   */
+  it('ConditionalCheckFailedException maps to HTTP 409', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { statusCode, body } = ErrorHandler.handle(
+      makeNamedError('ConditionalCheckFailedException')
+    )
+
+    expect(statusCode).toBe(409)
+    expect((body.error as any).code).toBe('CONFLICT')
+  })
+
+  /**
+   * JSON SyntaxError maps to 400 with INVALID_JSON code.
+   */
+  it('JSON SyntaxError maps to HTTP 400 with INVALID_JSON', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const jsonError = new SyntaxError('Unexpected token in JSON at position 0')
+    const { statusCode, body } = ErrorHandler.handle(jsonError)
+
+    expect(statusCode).toBe(400)
+    expect((body.error as any).code).toBe('INVALID_JSON')
+  })
+
+  /**
+   * Unknown/generic errors always map to 500 and never leak internal details.
+   */
+  it('generic errors map to HTTP 500 without leaking internal details', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { statusCode, body } = ErrorHandler.handle(new Error(msg))
+
+        expect(statusCode).toBe(500)
+        expect((body.error as any).code).toBe('INTERNAL_ERROR')
+        // The original message must NOT appear in the response body
+        expect((body.error as any).message).toBe('An unexpected error occurred')
+        expect((body.error as any).message).not.toBe(msg)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * The response body always has the shape { error: { code, message } }.
+   */
+  it('response body always has consistent { error: { code, message } } shape', () => {
+    const errorFactories = [
+      () => new ValidationError('v'),
+      () => new AuthenticationError('a'),
+      () => new AuthorizationError('z'),
+      () => new NotFoundError('n'),
+      () => new Error('generic'),
+      () => makeNamedError('ResourceNotFoundException'),
+      () => 'string throw',
+      () => 42,
+      () => null,
+    ]
+
+    for (const factory of errorFactories) {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { body } = ErrorHandler.handle(factory())
+
+      expect(body).toHaveProperty('error')
+      const errorObj = body.error as any
+      expect(typeof errorObj.code).toBe('string')
+      expect(errorObj.code.length).toBeGreaterThan(0)
+      expect(typeof errorObj.message).toBe('string')
+      expect(errorObj.message.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ── Property 47: Structured logging format ───────────────────────────────────
+
+describe('[NFR-OPS-02] Property 47: Structured logging format', () => {
+  /**
+   * Every log entry contains timestamp, level, code, message, and statusCode.
+   */
+  it('every log entry contains all required fields', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        const errors: unknown[] = [
+          new ValidationError(msg),
+          new AuthenticationError(msg),
+          new AuthorizationError(msg),
+          new NotFoundError(msg),
+          new Error(msg),
+          msg, // non-Error throw
+        ]
+
+        for (const error of errors) {
+          vi.spyOn(console, 'error').mockImplementation(() => {})
+          const { logEntry } = ErrorHandler.handle(error)
+
+          expect(logEntry).toHaveProperty('timestamp')
+          expect(logEntry).toHaveProperty('level')
+          expect(logEntry).toHaveProperty('code')
+          expect(logEntry).toHaveProperty('message')
+          expect(logEntry).toHaveProperty('statusCode')
+        }
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * The timestamp is a valid ISO 8601 string.
+   */
+  it('timestamp is a valid ISO 8601 string', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { logEntry } = ErrorHandler.handle(new Error(msg))
+
+        const parsed = new Date(logEntry.timestamp)
+        expect(parsed.toISOString()).toBe(logEntry.timestamp)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * Client errors (4xx) are logged at 'warn' level;
+   * server errors (5xx) are logged at 'error' level.
+   */
+  it('4xx errors log at warn level, 5xx errors log at error level', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        // 4xx → warn
+        const { logEntry: warnEntry } = ErrorHandler.handle(new ValidationError(msg))
+        expect(warnEntry.level).toBe('warn')
+
+        // 5xx → error
+        const { logEntry: errorEntry } = ErrorHandler.handle(new Error(msg))
+        expect(errorEntry.level).toBe('error')
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * Error instances include a stack trace in the log entry.
+   */
+  it('Error instances include a stack trace in the log entry', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { logEntry } = ErrorHandler.handle(new NotFoundError(msg))
+
+        expect(logEntry.stack).toBeDefined()
+        expect(typeof logEntry.stack).toBe('string')
+        expect(logEntry.stack!.length).toBeGreaterThan(0)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * Non-Error thrown values do NOT include a stack trace.
+   */
+  it('non-Error thrown values do not include a stack trace', () => {
+    fc.assert(
+      fc.property(fc.string(), (thrown) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const { logEntry } = ErrorHandler.handle(thrown)
+
+        expect(logEntry.stack).toBeUndefined()
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * The log line emitted to console.error is valid JSON that can be parsed
+   * back into an ErrorLogEntry.
+   */
+  it('console.error output is valid parseable JSON', () => {
+    fc.assert(
+      fc.property(messageArb, (msg) => {
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        ErrorHandler.handle(new AuthorizationError(msg))
+
+        const logLine = spy.mock.calls[0][0] as string
+        const parsed: ErrorLogEntry = JSON.parse(logLine)
+
+        expect(parsed.timestamp).toBeDefined()
+        expect(parsed.level).toBe('warn')
+        expect(parsed.code).toBe('AUTHORIZATION_ERROR')
+        expect(parsed.statusCode).toBe(403)
+        spy.mockRestore()
+      }),
+      { numRuns: 100 }
+    )
+  })
+})
+
+// ── Property: toResponse() produces complete API Gateway responses ────────────
+
+describe('[NFR-USA-04] ErrorHandler.toResponse()', () => {
+  /**
+   * toResponse() returns a complete API Gateway response with statusCode,
+   * headers, and a JSON-parseable body string.
+   */
+  it('produces a complete API Gateway response with headers and JSON body', () => {
+    fc.assert(
+      fc.property(messageArb, corsHeadersArb, (msg, headers) => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        const response = ErrorHandler.toResponse(new NotFoundError(msg), headers)
+
+        expect(response.statusCode).toBe(404)
+        expect(response.headers).toEqual(headers)
+
+        const parsed = JSON.parse(response.body)
+        expect(parsed.error.code).toBe('NOT_FOUND')
+        expect(parsed.error.message).toBe(msg)
+      }),
+      { numRuns: 100 }
+    )
+  })
+
+  /**
+   * toResponse() preserves CORS headers exactly as provided.
+   */
+  it('preserves CORS headers exactly as provided', () => {
+    fc.assert(
+      fc.property(
+        fc.dictionary(
+          fc.stringMatching(/^[A-Za-z-]{1,30}$/),
+          fc.stringMatching(/^[a-zA-Z0-9*,. ]{1,50}$/),
+          { minKeys: 1, maxKeys: 5 }
+        ),
+        (headers) => {
+          vi.spyOn(console, 'error').mockImplementation(() => {})
+          const response = ErrorHandler.toResponse(new Error('test'), headers)
+
+          expect(response.headers).toEqual(headers)
+        }
+      ),
+      { numRuns: 100 }
+    )
+  })
+})

--- a/backend/tests/error-handler.unit.test.ts
+++ b/backend/tests/error-handler.unit.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Unit tests for error handling scenarios
+ *
+ * Tests concrete, realistic error scenarios to verify:
+ * - Validation errors return 400 with field details
+ * - Authentication errors return 401
+ * - Authorization errors return 403
+ * - Not found errors return 404
+ *
+ * Requirements: [NFR-OPS-02], [NFR-USA-04]
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  AppError,
+  ValidationError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ErrorHandler,
+} from '../src/errors/index'
+import { ValidationException } from '../src/validation/validators'
+
+// Suppress console.error output during tests
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// ── Custom Error Class Construction ─────────────────────────────────────────
+
+describe('Custom error classes', () => {
+  describe('ValidationError', () => {
+    it('has statusCode 400 and code VALIDATION_ERROR', () => {
+      const error = new ValidationError()
+      expect(error.statusCode).toBe(400)
+      expect(error.code).toBe('VALIDATION_ERROR')
+      expect(error.name).toBe('ValidationError')
+    })
+
+    it('uses default message when none provided', () => {
+      const error = new ValidationError()
+      expect(error.message).toBe('Validation failed')
+    })
+
+    it('accepts custom message and field details', () => {
+      const details = [
+        { field: 'name', message: 'Name is required' },
+        { field: 'age', message: 'Age must be a non-negative integer' },
+      ]
+      const error = new ValidationError('Pet data invalid', details)
+      expect(error.message).toBe('Pet data invalid')
+      expect(error.details).toEqual(details)
+    })
+
+    it('details are undefined when not provided', () => {
+      const error = new ValidationError('Missing fields')
+      expect(error.details).toBeUndefined()
+    })
+
+    it('is an instance of AppError and Error', () => {
+      const error = new ValidationError()
+      expect(error).toBeInstanceOf(AppError)
+      expect(error).toBeInstanceOf(Error)
+    })
+
+    it('has a stack trace', () => {
+      const error = new ValidationError()
+      expect(error.stack).toBeDefined()
+      expect(error.stack).toContain('ValidationError')
+    })
+  })
+
+  describe('AuthenticationError', () => {
+    it('has statusCode 401 and code AUTHENTICATION_ERROR', () => {
+      const error = new AuthenticationError()
+      expect(error.statusCode).toBe(401)
+      expect(error.code).toBe('AUTHENTICATION_ERROR')
+      expect(error.name).toBe('AuthenticationError')
+    })
+
+    it('uses default message when none provided', () => {
+      const error = new AuthenticationError()
+      expect(error.message).toBe('Authentication required')
+    })
+
+    it('accepts custom message', () => {
+      const error = new AuthenticationError('Token expired')
+      expect(error.message).toBe('Token expired')
+    })
+
+    it('is an instance of AppError and Error', () => {
+      const error = new AuthenticationError()
+      expect(error).toBeInstanceOf(AppError)
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('AuthorizationError', () => {
+    it('has statusCode 403 and code AUTHORIZATION_ERROR', () => {
+      const error = new AuthorizationError()
+      expect(error.statusCode).toBe(403)
+      expect(error.code).toBe('AUTHORIZATION_ERROR')
+      expect(error.name).toBe('AuthorizationError')
+    })
+
+    it('uses default message when none provided', () => {
+      const error = new AuthorizationError()
+      expect(error.message).toBe('Access denied')
+    })
+
+    it('accepts custom message', () => {
+      const error = new AuthorizationError('Only veterinarians can create pet profiles')
+      expect(error.message).toBe('Only veterinarians can create pet profiles')
+    })
+
+    it('is an instance of AppError and Error', () => {
+      const error = new AuthorizationError()
+      expect(error).toBeInstanceOf(AppError)
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
+
+  describe('NotFoundError', () => {
+    it('has statusCode 404 and code NOT_FOUND', () => {
+      const error = new NotFoundError()
+      expect(error.statusCode).toBe(404)
+      expect(error.code).toBe('NOT_FOUND')
+      expect(error.name).toBe('NotFoundError')
+    })
+
+    it('uses default message when none provided', () => {
+      const error = new NotFoundError()
+      expect(error.message).toBe('Resource not found')
+    })
+
+    it('accepts custom message', () => {
+      const error = new NotFoundError('Pet pet-456 not found')
+      expect(error.message).toBe('Pet pet-456 not found')
+    })
+
+    it('is an instance of AppError and Error', () => {
+      const error = new NotFoundError()
+      expect(error).toBeInstanceOf(AppError)
+      expect(error).toBeInstanceOf(Error)
+    })
+  })
+})
+
+// ── Validation errors return 400 with field details ─────────────────────────
+
+describe('Validation errors return 400 with field details', () => {
+  it('returns 400 with field-level details for missing pet name', () => {
+    const details = [{ field: 'name', message: 'Name is required' }]
+    const { statusCode, body } = ErrorHandler.handle(new ValidationError('Validation failed', details))
+
+    expect(statusCode).toBe(400)
+    expect((body.error as any).code).toBe('VALIDATION_ERROR')
+    expect((body.error as any).details).toEqual(details)
+  })
+
+  it('returns 400 with multiple field errors', () => {
+    const details = [
+      { field: 'name', message: 'Name is required' },
+      { field: 'species', message: 'Species is required' },
+      { field: 'age', message: 'Age must be a non-negative integer' },
+    ]
+    const { statusCode, body } = ErrorHandler.handle(new ValidationError('Validation failed', details))
+
+    expect(statusCode).toBe(400)
+    expect((body.error as any).details).toHaveLength(3)
+    expect((body.error as any).details[0].field).toBe('name')
+    expect((body.error as any).details[1].field).toBe('species')
+    expect((body.error as any).details[2].field).toBe('age')
+  })
+
+  it('returns 400 without details when none provided', () => {
+    const { statusCode, body } = ErrorHandler.handle(new ValidationError('Invalid input'))
+
+    expect(statusCode).toBe(400)
+    expect((body.error as any).code).toBe('VALIDATION_ERROR')
+    expect((body.error as any).details).toBeUndefined()
+  })
+
+  it('handles legacy ValidationException with field details', () => {
+    const details = [
+      { field: 'ownerEmail', message: 'Invalid email format' },
+      { field: 'ownerPhone', message: 'Phone must have at least 10 digits' },
+    ]
+    const exception = new ValidationException(details)
+    const { statusCode, body } = ErrorHandler.handle(exception)
+
+    expect(statusCode).toBe(400)
+    expect((body.error as any).code).toBe('VALIDATION_ERROR')
+    expect((body.error as any).details).toEqual(details)
+  })
+
+  it('handles JSON parse error as 400', () => {
+    const jsonError = new SyntaxError('Unexpected token < in JSON at position 0')
+    const { statusCode, body } = ErrorHandler.handle(jsonError)
+
+    expect(statusCode).toBe(400)
+    expect((body.error as any).code).toBe('INVALID_JSON')
+    expect((body.error as any).message).toBe('Request body contains invalid JSON')
+  })
+})
+
+// ── Authentication errors return 401 ────────────────────────────────────────
+
+describe('Authentication errors return 401', () => {
+  it('returns 401 for missing authentication', () => {
+    const { statusCode, body } = ErrorHandler.handle(new AuthenticationError())
+
+    expect(statusCode).toBe(401)
+    expect((body.error as any).code).toBe('AUTHENTICATION_ERROR')
+    expect((body.error as any).message).toBe('Authentication required')
+  })
+
+  it('returns 401 for expired token', () => {
+    const { statusCode, body } = ErrorHandler.handle(new AuthenticationError('Token expired'))
+
+    expect(statusCode).toBe(401)
+    expect((body.error as any).message).toBe('Token expired')
+  })
+
+  it('returns 401 for invalid token', () => {
+    const { statusCode, body } = ErrorHandler.handle(new AuthenticationError('Invalid JWT token'))
+
+    expect(statusCode).toBe(401)
+    expect((body.error as any).message).toBe('Invalid JWT token')
+  })
+})
+
+// ── Authorization errors return 403 ─────────────────────────────────────────
+
+describe('Authorization errors return 403', () => {
+  it('returns 403 for owner trying to create medical profile', () => {
+    const { statusCode, body } = ErrorHandler.handle(
+      new AuthorizationError('Only veterinarians can create pet profiles')
+    )
+
+    expect(statusCode).toBe(403)
+    expect((body.error as any).code).toBe('AUTHORIZATION_ERROR')
+    expect((body.error as any).message).toBe('Only veterinarians can create pet profiles')
+  })
+
+  it('returns 403 for vet trying to claim a profile', () => {
+    const { statusCode, body } = ErrorHandler.handle(
+      new AuthorizationError('Only pet owners can claim profiles')
+    )
+
+    expect(statusCode).toBe(403)
+    expect((body.error as any).message).toBe('Only pet owners can claim profiles')
+  })
+
+  it('returns 403 for accessing another clinic\'s pets', () => {
+    const { statusCode, body } = ErrorHandler.handle(
+      new AuthorizationError('You can only access pets from your own clinic')
+    )
+
+    expect(statusCode).toBe(403)
+    expect((body.error as any).message).toBe('You can only access pets from your own clinic')
+  })
+
+  it('returns 403 with default message', () => {
+    const { statusCode, body } = ErrorHandler.handle(new AuthorizationError())
+
+    expect(statusCode).toBe(403)
+    expect((body.error as any).message).toBe('Access denied')
+  })
+})
+
+// ── Not found errors return 404 ─────────────────────────────────────────────
+
+describe('Not found errors return 404', () => {
+  it('returns 404 for missing pet', () => {
+    const { statusCode, body } = ErrorHandler.handle(new NotFoundError('Pet pet-456 not found'))
+
+    expect(statusCode).toBe(404)
+    expect((body.error as any).code).toBe('NOT_FOUND')
+    expect((body.error as any).message).toBe('Pet pet-456 not found')
+  })
+
+  it('returns 404 for missing clinic', () => {
+    const { statusCode, body } = ErrorHandler.handle(new NotFoundError('Clinic clinic-123 not found'))
+
+    expect(statusCode).toBe(404)
+    expect((body.error as any).message).toBe('Clinic clinic-123 not found')
+  })
+
+  it('returns 404 for AWS ResourceNotFoundException', () => {
+    const awsError = new Error('Requested resource not found')
+    awsError.name = 'ResourceNotFoundException'
+    const { statusCode, body } = ErrorHandler.handle(awsError)
+
+    expect(statusCode).toBe(404)
+    expect((body.error as any).code).toBe('NOT_FOUND')
+  })
+
+  it('returns 404 with default message', () => {
+    const { statusCode, body } = ErrorHandler.handle(new NotFoundError())
+
+    expect(statusCode).toBe(404)
+    expect((body.error as any).message).toBe('Resource not found')
+  })
+})
+
+// ── Internal server errors (500) ────────────────────────────────────────────
+
+describe('Internal server errors return 500', () => {
+  it('returns 500 for unexpected Error and hides internal message', () => {
+    const { statusCode, body } = ErrorHandler.handle(new Error('Database connection failed'))
+
+    expect(statusCode).toBe(500)
+    expect((body.error as any).code).toBe('INTERNAL_ERROR')
+    expect((body.error as any).message).toBe('An unexpected error occurred')
+    // Must NOT leak the internal error message
+    expect((body.error as any).message).not.toContain('Database')
+  })
+
+  it('returns 500 for thrown string', () => {
+    const { statusCode, body } = ErrorHandler.handle('something went wrong')
+
+    expect(statusCode).toBe(500)
+    expect((body.error as any).code).toBe('INTERNAL_ERROR')
+  })
+
+  it('returns 500 for thrown null', () => {
+    const { statusCode, body } = ErrorHandler.handle(null)
+
+    expect(statusCode).toBe(500)
+    expect((body.error as any).code).toBe('INTERNAL_ERROR')
+  })
+
+  it('returns 500 for thrown undefined', () => {
+    const { statusCode, body } = ErrorHandler.handle(undefined)
+
+    expect(statusCode).toBe(500)
+    expect((body.error as any).code).toBe('INTERNAL_ERROR')
+  })
+})
+
+// ── Conflict errors (409) ───────────────────────────────────────────────────
+
+describe('Conflict errors return 409', () => {
+  it('returns 409 for ConditionalCheckFailedException', () => {
+    const awsError = new Error('The conditional request failed')
+    awsError.name = 'ConditionalCheckFailedException'
+    const { statusCode, body } = ErrorHandler.handle(awsError)
+
+    expect(statusCode).toBe(409)
+    expect((body.error as any).code).toBe('CONFLICT')
+  })
+})
+
+// ── Structured log entry content ────────────────────────────────────────────
+
+describe('Structured log entries', () => {
+  it('includes handler context in log entry', () => {
+    const context = { handler: 'PetCoOnboardingHandler', petId: 'pet-456' }
+    const { logEntry } = ErrorHandler.handle(new NotFoundError('Pet not found'), context)
+
+    expect(logEntry.context).toEqual(context)
+    expect(logEntry.context!.handler).toBe('PetCoOnboardingHandler')
+    expect(logEntry.context!.petId).toBe('pet-456')
+  })
+
+  it('log entry has warn level for 4xx errors', () => {
+    const { logEntry: v } = ErrorHandler.handle(new ValidationError())
+    const { logEntry: a } = ErrorHandler.handle(new AuthenticationError())
+    const { logEntry: z } = ErrorHandler.handle(new AuthorizationError())
+    const { logEntry: n } = ErrorHandler.handle(new NotFoundError())
+
+    expect(v.level).toBe('warn')
+    expect(a.level).toBe('warn')
+    expect(z.level).toBe('warn')
+    expect(n.level).toBe('warn')
+  })
+
+  it('log entry has error level for 5xx errors', () => {
+    const { logEntry } = ErrorHandler.handle(new Error('unexpected'))
+
+    expect(logEntry.level).toBe('error')
+  })
+
+  it('log entry timestamp is a valid ISO 8601 date', () => {
+    const { logEntry } = ErrorHandler.handle(new Error('test'))
+    const parsed = new Date(logEntry.timestamp)
+
+    expect(parsed.toISOString()).toBe(logEntry.timestamp)
+  })
+
+  it('log entry includes stack trace for Error instances', () => {
+    const { logEntry } = ErrorHandler.handle(new ValidationError('bad input'))
+
+    expect(logEntry.stack).toBeDefined()
+    expect(logEntry.stack).toContain('ValidationError')
+  })
+
+  it('log entry omits stack trace for non-Error throws', () => {
+    const { logEntry } = ErrorHandler.handle('string error')
+
+    expect(logEntry.stack).toBeUndefined()
+  })
+
+  it('emits valid JSON to console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ErrorHandler.handle(new AuthorizationError('forbidden'))
+
+    expect(spy).toHaveBeenCalledOnce()
+    const logLine = spy.mock.calls[0][0] as string
+    const parsed = JSON.parse(logLine)
+
+    expect(parsed.code).toBe('AUTHORIZATION_ERROR')
+    expect(parsed.statusCode).toBe(403)
+    expect(parsed.message).toBe('forbidden')
+    spy.mockRestore()
+  })
+})
+
+// ── toResponse() integration ────────────────────────────────────────────────
+
+describe('ErrorHandler.toResponse()', () => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+  }
+
+  it('returns complete API Gateway response for validation error', () => {
+    const details = [{ field: 'name', message: 'Name is required' }]
+    const response = ErrorHandler.toResponse(new ValidationError('Invalid', details), corsHeaders)
+
+    expect(response.statusCode).toBe(400)
+    expect(response.headers).toEqual(corsHeaders)
+
+    const parsed = JSON.parse(response.body)
+    expect(parsed.error.code).toBe('VALIDATION_ERROR')
+    expect(parsed.error.details).toEqual(details)
+  })
+
+  it('returns complete API Gateway response for 500 error', () => {
+    const response = ErrorHandler.toResponse(new Error('db crash'), corsHeaders)
+
+    expect(response.statusCode).toBe(500)
+    expect(response.headers).toEqual(corsHeaders)
+
+    const parsed = JSON.parse(response.body)
+    expect(parsed.error.code).toBe('INTERNAL_ERROR')
+    expect(parsed.error.message).not.toContain('db crash')
+  })
+
+  it('passes context through to log entry', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ErrorHandler.toResponse(
+      new NotFoundError(),
+      corsHeaders,
+      { handler: 'ClinicHandler', clinicId: 'clinic-123' }
+    )
+
+    const logLine = spy.mock.calls[0][0] as string
+    const parsed = JSON.parse(logLine)
+    expect(parsed.context.handler).toBe('ClinicHandler')
+    expect(parsed.context.clinicId).toBe('clinic-123')
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
**Description:**

Resolves #78 and resolves #79.

This pull request add property-based and unit tests for the centralized ErrorHandler introduced in #77, verifying error classification, structured logging, and consistent API response formatting.

**Definition of Done Checklist:**

- [x] Error logging — for any error, the handler logs a structured JSON entry with timestamp, context, and stack trace
- [x] API error responses — Status code mapping, legacy ValidationException, AWS SDK errors, JSON parse errors, no detail leakage, consistent shape
- [x] Structured logging format — all log entries are valid, parseable JSON with required fields
- [x] Validation errors return 400 with field details — single field, multiple fields, no details, legacy ValidationException, JSON parse
- [x] Authentication errors return 401 — missing auth, expired token, invalid token
- [x] Authorization errors return 403 — vet-only, owner-only, cross-clinic, default message
- [x] Not found errors return 404 — missing pet, missing clinic, AWS ResourceNotFoundException, default
- [x] Unexpected errors return 500 with generic message — generic Error with message hidden, thrown string, null, undefined

**Changes**

**New file** `backend/tests/error-handler.property.test.ts`: 22 property tests using fast-check with numRuns: 100

**New file** `error-handler.unit.test.ts`: 
 - 49 unit tests covering concrete error scenarios
 - Validation errors return 400 with field details
 - Authentication errors return 401
 - Authorization errors return 403
 - Not found errors return 404
 - Internal errors return 500 without leaking details

**What was tested**
 - All 71 new tests pass (22 property + 49 unit)
 - All 241 pre-existing tests pass
 - TypeScript compiles with zero errors

Validates Requirements: [NFR-OPS-02], [NFR-USA-04]