### PR TITLE
fix: resolve Docker hostname issues in signed URLs and config

### DIFF
--- a/backend/src/repositories/care-snapshot-repository.ts
+++ b/backend/src/repositories/care-snapshot-repository.ts
@@ -72,7 +72,7 @@ export class CareSnapshotRepository {
       snapshotId,
       petName: snapshot.petName,
       accessCode,
-      accessUrl: `${process.env.APP_BASE_URL || (process.env.IS_LOCAL === 'true' ? 'http://localhost:5173' : 'https://app.pawprintprofile.com')}/care/${accessCode}`,
+      accessUrl: `${process.env.APP_BASE_URL || (process.env.IS_LOCAL === 'true' ? 'http://localhost:8080' : 'https://app.pawprintprofile.com')}/care/${accessCode}`,
       expiryDate,
     }
   }

--- a/backend/src/repositories/image-repository.ts
+++ b/backend/src/repositories/image-repository.ts
@@ -124,7 +124,21 @@ export class ImageRepository {
       Key: image.s3Key,
     })
 
-    return getSignedUrl(this.s3Client, command, { expiresIn: SIGNED_URL_EXPIRES_IN })
+    return this.toPublicUrl(
+      await getSignedUrl(this.s3Client, command, { expiresIn: SIGNED_URL_EXPIRES_IN })
+    )
+  }
+
+  /**
+   * Replace Docker-internal hostnames in S3 signed URLs with localhost
+   * so the browser can reach them during local development.
+   */
+  private toPublicUrl(url: string): string {
+    const localstackHost = process.env.LOCALSTACK_HOSTNAME
+    if (localstackHost && localstackHost !== 'localhost') {
+      return url.replace(`http://${localstackHost}:`, 'http://localhost:')
+    }
+    return url
   }
 
   /**

--- a/backend/src/services/flyer-generation-service.ts
+++ b/backend/src/services/flyer-generation-service.ts
@@ -117,7 +117,11 @@ export class FlyerGenerationService {
       expiresIn: SIGNED_URL_EXPIRES_IN,
     })
 
-    return { flyerUrl, s3Key, generatedAt }
+    // In local dev, the signed URL uses the Docker-internal hostname (e.g. "localstack").
+    // Replace it with localhost so the browser can reach it.
+    const publicFlyerUrl = this.toPublicUrl(flyerUrl)
+
+    return { flyerUrl: publicFlyerUrl, s3Key, generatedAt }
   }
 
   /**
@@ -320,5 +324,17 @@ export class FlyerGenerationService {
       default:
         return 'Contact via Paw Print Profile platform'
     }
+  }
+
+  /**
+   * Replace Docker-internal hostnames in S3 signed URLs with localhost
+   * so the browser can reach them during local development.
+   */
+  private toPublicUrl(url: string): string {
+    const localstackHost = process.env.LOCALSTACK_HOSTNAME
+    if (localstackHost && localstackHost !== 'localhost') {
+      return url.replace(`http://${localstackHost}:`, 'http://localhost:')
+    }
+    return url
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - "8080:8080"  # Frontend application port
     environment:
       # API endpoint configuration
-      - VITE_API_URL=http://backend:3000
+      - VITE_API_URL=http://localhost:3000
       - VITE_IS_LOCAL=true
     depends_on:
       - backend


### PR DESCRIPTION
**Description:**

Fix three Docker hostname issues that prevented the application from working correctly when running via Docker Compose.

**Problems**

1. **VITE_API_URL** in docker-compose.yml was set to `http://backend:3000` (Docker-internal). Since Vite embeds this into client-side JavaScript, the browser couldn't resolve the hostname. All API calls failed.

2. **S3 signed URLs** for flyers and pet images used the Docker-internal `localstack` hostname (e.g., `http://localstack:4566/...`). The browser couldn't download PDFs or load images.

3. **Care snapshot accessUrl** used port 5173 (Vite default) instead of 8080 (Docker-mapped port). Clicking the care snapshot link opened a blank page.

**Fixes**

| File | Fix |
|------|-----|
| `docker-compose.yml` | Changed `VITE_API_URL` from `http://backend:3000` to `http://localhost:3000` |
| `backend/src/services/flyer-generation-service.ts` | Added `toPublicUrl()` to replace Docker-internal hostname with `localhost` in signed URLs |
| `backend/src/repositories/image-repository.ts` | Added `toPublicUrl()` for image signed URLs |
| `backend/src/repositories/care-snapshot-repository.ts` | Changed fallback port from 5173 to 8080 |

**What was tested**

- Flyer download opens PDF in new tab (was blank page)
- Search results load correctly (was CORS/network error)
- Care snapshot URL is clickable and resolves (was wrong port)
- All 241+ backend tests still pass