### PR TITLE
fix: read S3 bucket name at call time instead of module load

### DIFF
--- a/backend/src/services/flyer-generation-service.ts
+++ b/backend/src/services/flyer-generation-service.ts
@@ -26,7 +26,9 @@ async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
   return Buffer.concat(chunks)
 }
 
-const FLYER_BUCKET = process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images'
+function getFlyerBucket(): string {
+  return process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images'
+}
 const SIGNED_URL_EXPIRES_IN = 3600 // 1 hour
 
 /**
@@ -97,7 +99,7 @@ export class FlyerGenerationService {
 
     await this.s3Client.send(
       new PutObjectCommand({
-        Bucket: FLYER_BUCKET,
+        Bucket: getFlyerBucket(),
         Key: s3Key,
         Body: pdfBuffer,
         ContentType: 'application/pdf',
@@ -110,7 +112,7 @@ export class FlyerGenerationService {
 
     // Generate a signed URL for download
     const command = new GetObjectCommand({
-      Bucket: FLYER_BUCKET,
+      Bucket: getFlyerBucket(),
       Key: s3Key,
     })
     const flyerUrl = await getSignedUrl(this.s3Client, command, {

--- a/backend/tests/lambda-handlers.integration.test.ts
+++ b/backend/tests/lambda-handlers.integration.test.ts
@@ -19,6 +19,8 @@ import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
 import { DynamoDBTableInitializer } from '../src/infrastructure/init-dynamodb'
 import { ClinicRepository } from '../src/repositories/clinic-repository'
 import { PetRepository } from '../src/repositories/pet-repository'
+import { AWSClientFactory } from '../src/infrastructure/aws-client-factory'
+import { CreateBucketCommand, DeleteBucketCommand, HeadBucketCommand } from '@aws-sdk/client-s3'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -89,6 +91,16 @@ beforeAll(async () => {
 
   initializer = new DynamoDBTableInitializer(TABLE_NAME)
   await initializer.initializeForTesting({ tableName: TABLE_NAME })
+
+  // Ensure the S3 bucket exists for flyer generation tests
+  const factory = new AWSClientFactory()
+  const s3Client = factory.createS3Client()
+  const bucketName = process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images-test'
+  try {
+    await s3Client.send(new HeadBucketCommand({ Bucket: bucketName }))
+  } catch {
+    await s3Client.send(new CreateBucketCommand({ Bucket: bucketName }))
+  }
 
   // Repositories for direct data setup
   clinicRepo = new ClinicRepository(TABLE_NAME)


### PR DESCRIPTION
**Description**

FlyerGenerationService was capturing `PET_IMAGES_BUCKET` env var at module load time via a top-level const. Tests that set the `env var` in beforeAll could not override it, causing `NoSuchBucket` errors in integration tests.

**Changes**

- Replace module-level `FLYER_BUCKET` const with `getFlyerBucket()` function that reads process.env at call time
- Add S3 bucket creation to `lambda-handlers.integration.test.ts` setup using `HeadBucket` check before `CreateBucket`

**What was tested**

All 436 backend tests pass (24 test files)

**Previously failing tests now pass:**

- `emergency-tools-service.property.test.ts` — flyer generation
- `lambda-handlers.integration.test.ts` — 3-click missing pet flyer endpoints
- `missing-pet-workflow.integration.test.ts` — Complete flow and notification assertions