### PR TITLE
Public search ux fixes

### DIFF
--- a/backend/src/handlers/search-handler.ts
+++ b/backend/src/handlers/search-handler.ts
@@ -91,11 +91,13 @@ async function handleSearch(event: APIGatewayProxyEvent, corsHeaders: Record<str
   const criteria: any = {}
 
   if (species) {
-    criteria.species = species
+    // Normalize to title case for GSI2 query (e.g., "cat" → "Cat", "DOG" → "Dog")
+    criteria.species = species.charAt(0).toUpperCase() + species.slice(1).toLowerCase()
   }
 
   if (breed) {
-    criteria.breed = breed
+    // Normalize breed to title case (e.g., "golden retriever" → "Golden Retriever")
+    criteria.breed = breed.split(' ').map((w: string) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ')
   }
 
   if (ageMin) {

--- a/backend/src/repositories/pet-repository.ts
+++ b/backend/src/repositories/pet-repository.ts
@@ -456,7 +456,7 @@ export class PetRepository {
 
       // Apply additional filters
       if (criteria.breed) {
-        pets = pets.filter(pet => pet.breed.toLowerCase().includes(criteria.breed!.toLowerCase()))
+        pets = pets.filter(pet => pet.breed && pet.breed.toLowerCase().includes(criteria.breed!.toLowerCase()))
       }
 
       if (criteria.ageMin !== undefined) {
@@ -483,7 +483,7 @@ export class PetRepository {
 
       // Apply filters
       if (criteria.breed) {
-        pets = pets.filter(pet => pet.breed.toLowerCase().includes(criteria.breed!.toLowerCase()))
+        pets = pets.filter(pet => pet.breed && pet.breed.toLowerCase().includes(criteria.breed!.toLowerCase()))
       }
 
       if (criteria.ageMin !== undefined) {

--- a/backend/src/services/search-service.ts
+++ b/backend/src/services/search-service.ts
@@ -82,7 +82,12 @@ export class SearchService {
 
       // Get images for this pet
       const petImages = await this.imageRepo.findByPet(pet.petId)
-      const images = petImages.map(img => ({ url: img.url, tags: img.tags }))
+      const images = await Promise.all(
+        petImages.map(async (img) => ({
+          url: await this.imageRepo.getUrl(img.imageId, pet.petId),
+          tags: img.tags,
+        }))
+      )
 
       const searchResult: SearchResult = {
         petId: pet.petId,
@@ -155,7 +160,12 @@ export class SearchService {
 
     // Get images for this pet
     const petImages = await this.imageRepo.findByPet(pet.petId)
-    const images = petImages.map(img => ({ url: img.url, tags: img.tags }))
+    const images = await Promise.all(
+      petImages.map(async (img) => ({
+        url: await this.imageRepo.getUrl(img.imageId, pet.petId),
+        tags: img.tags,
+      }))
+    )
 
     return {
       petId: pet.petId,
@@ -226,7 +236,12 @@ export class SearchService {
 
           // Get images for this pet
           const petImages = await this.imageRepo.findByPet(pet.petId)
-          const images = petImages.map(img => ({ url: img.url, tags: img.tags }))
+          const images = await Promise.all(
+            petImages.map(async (img) => ({
+              url: await this.imageRepo.getUrl(img.imageId, pet.petId),
+              tags: img.tags,
+            }))
+          )
 
           const searchResult: SearchResult = {
             petId: pet.petId,

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -96,12 +96,20 @@ export function SearchPage() {
       {/* Search filters */}
       <form className="search-form" onSubmit={handleSearch}>
         <div className="form-row">
-          <input
-            placeholder="Species (e.g., Dog, Cat)"
+          <select
             value={filters.species}
             onChange={(e) => updateFilter('species', e.target.value)}
             aria-label="Species"
-          />
+          >
+            <option value="">All Species</option>
+            <option value="Dog">Dog</option>
+            <option value="Cat">Cat</option>
+            <option value="Bird">Bird</option>
+            <option value="Rabbit">Rabbit</option>
+            <option value="Hamster">Hamster</option>
+            <option value="Reptile">Reptile</option>
+            <option value="Other">Other</option>
+          </select>
           <input
             placeholder="Breed (e.g., Golden Retriever)"
             value={filters.breed}

--- a/frontend/src/pages/vet/VetDashboard.tsx
+++ b/frontend/src/pages/vet/VetDashboard.tsx
@@ -21,13 +21,24 @@ interface PendingPet {
 export function VetDashboard() {
   const { clinicId } = useAuth()
   const [pendingClaims, setPendingClaims] = useState<PendingPet[]>([])
+  const [clinicName, setClinicName] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!clinicId) return
     loadPendingClaims()
+    loadClinicName()
   }, [clinicId])
+
+  async function loadClinicName() {
+    try {
+      const data = await api.get<{ name: string }>(`/clinics/${clinicId}`)
+      setClinicName(data.name)
+    } catch {
+      // Non-critical — just won't show clinic name
+    }
+  }
 
   async function loadPendingClaims() {
     try {
@@ -45,7 +56,7 @@ export function VetDashboard() {
   return (
     <div>
       <h2>Clinic Dashboard</h2>
-      <p className="text-muted">Clinic ID: {clinicId || 'Not set'}</p>
+      {clinicName && <p className="text-muted">{clinicName}</p>}
 
       <div style={{ display: 'flex', gap: '15px', margin: '20px 0' }}>
         <Link to="/vet/pets/new">


### PR DESCRIPTION
**Description**

Resolves #125.

This pull request fixes several usability issues discovered during manual testing of the public lost pet search, plus a UX improvement to the vet dashboard.

**Bugs Fixed**

1. **Species search case-sensitivity** — Searching for "cat" (lowercase) returned no results because DynamoDB GSI2 stores species with exact casing (`SPECIES#Cat`). Fixed by replacing the free-text input with a dropdown selector.
2. **Breed search case-sensitivity** — Searching for "golden retriever" didn't match "Golden Retriever". Fixed by normalizing breed input to title case on the backend.
3. **500 error when searching by breed without species** — The fallback scan returned non-pet records (clinics, users) that lack a `breed` field, causing `Cannot read properties of undefined`. Fixed by adding null safety to the breed filter.
4. **Pet images not rendering:** Search results return raw s3:// protocol URIs instead of browser-accessible HTTP URLs. Images show as broken (question mark icon with alt text "Photo of [pet name]").

**Changes**

| File | Change |
|---|---|
| `frontend/src/pages/SearchPage.tsx` | Replace species text input with `<select>` dropdown (Dog, Cat, Bird, Rabbit, Hamster, Reptile, Other) |
| `backend/src/handlers/search-handler.ts` | Normalize species to title case, normalize breed to title case (each word) |
| `backend/src/repositories/pet-repository.ts` | Add `pet.breed &&` null check to breed filter in both GSI2 and scan paths |
| `frontend/src/pages/vet/VetDashboard.tsx` | Replace clinic ID display with clinic name (fetched from `GET /clinics/{clinicId}`) |
| `backend/src/services/search-service.ts` | The `SearchService` now fetches signed image URLs dynamically for each pet image using `getUrl`, ensuring that returned image URLs are always valid and up-to-date. This change is applied in all relevant search result methods.  |

**Testing**
- `curl 'http://localhost:3000/search/pets?breed=Golden+Retriever'` → returns `{"results":[],"count":0}` (no 500)
- `curl 'http://localhost:3000/search/pets?species=cat'` → normalizes to "Cat" and returns matching results
- All 58 frontend tests pass, TypeScript compiles cleanly

**Requirements Traceability**

- [FR-11] Public Lost Pet Search
- [NFR-USA-04] Error Messages (no more 500 for valid search input)