### PR TITLE
fix(#151): Replace hardcoded app URL with APP_BASE_URL env var

### DIFF
--- a/backend/src/handlers/search-handler.ts
+++ b/backend/src/handlers/search-handler.ts
@@ -145,7 +145,7 @@ async function handleSearch(event: APIGatewayProxyEvent, corsHeaders: Record<str
       ...r,
       owner: undefined,
       contactMethod: 'platform_messaging' as const,
-      messageUrl: `https://app.pawprintprofile.com/contact/${r.petId}`,
+      messageUrl: `${process.env.APP_BASE_URL || 'https://app.pawprintprofile.com'}/contact/${r.petId}`,
     }))
   } else {
     // Public search: only missing pets, owner contact hidden [FR-11][FR-15]
@@ -200,7 +200,7 @@ async function handleGetPetDetails(event: APIGatewayProxyEvent, corsHeaders: Rec
     ...petDetails,
     owner: undefined,
     contactMethod: 'platform_messaging' as const,
-    messageUrl: `https://app.pawprintprofile.com/contact/${petDetails.petId}`,
+    messageUrl: `${process.env.APP_BASE_URL || 'https://app.pawprintprofile.com'}/contact/${petDetails.petId}`,
   }
 
   return {

--- a/backend/src/services/search-service.ts
+++ b/backend/src/services/search-service.ts
@@ -140,7 +140,7 @@ export class SearchService {
       // Strip owner contact info — public users use platform messaging
       owner: undefined,
       contactMethod: 'platform_messaging' as const,
-      messageUrl: `https://app.pawprintprofile.com/contact/${result.petId}`,
+      messageUrl: `${process.env.APP_BASE_URL || 'https://app.pawprintprofile.com'}/contact/${result.petId}`,
     }))
   }
 

--- a/scripts/build-and-deploy.sh
+++ b/scripts/build-and-deploy.sh
@@ -3,11 +3,15 @@
 # Builds and deploys the backend SAM stack.
 # Includes post-build step to install pdfkit (with font data files)
 # into the EmergencyTools Lambda package.
+# Automatically resolves the frontend CloudFront URL for APP_BASE_URL.
 #
 # Usage:
 #   ./scripts/build-and-deploy.sh
 
 set -e
+
+REGION="eu-central-1"
+FRONTEND_STACK_NAME="paw-print-profile-frontend"
 
 echo "🔨 Building SAM template..."
 sam build
@@ -15,7 +19,22 @@ sam build
 echo "📦 Installing pdfkit into EmergencyTools Lambda package..."
 npm install --prefix .aws-sam/build/EmergencyToolsFunction pdfkit --quiet 2>/dev/null
 
+# Resolve frontend URL from CloudFront stack (if deployed)
+APP_BASE_URL="http://localhost:8080"
+FRONTEND_URL=$(aws cloudformation describe-stacks \
+  --stack-name "$FRONTEND_STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='FrontendUrl'].OutputValue" \
+  --output text 2>/dev/null || echo "")
+
+if [ -n "$FRONTEND_URL" ] && [ "$FRONTEND_URL" != "None" ]; then
+  APP_BASE_URL="$FRONTEND_URL"
+  echo "🌐 Frontend URL resolved: $APP_BASE_URL"
+else
+  echo "⚠ Frontend stack not found, using default: $APP_BASE_URL"
+fi
+
 echo "🚀 Deploying..."
-sam deploy --no-confirm-changeset
+sam deploy --no-confirm-changeset --parameter-overrides "AppBaseUrl=$APP_BASE_URL"
 
 echo "✅ Backend deployed successfully!"

--- a/template.yaml
+++ b/template.yaml
@@ -31,6 +31,11 @@ Parameters:
       - WARN
       - ERROR
 
+  AppBaseUrl:
+    Type: String
+    Default: 'http://localhost:8080'
+    Description: Frontend application URL (CloudFront URL in production)
+
 Globals:
   Function:
     Runtime: nodejs22.x
@@ -49,6 +54,7 @@ Globals:
         ENVIRONMENT: !Ref Environment
         LOG_LEVEL: !Ref LogLevel
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+        APP_BASE_URL: !Ref AppBaseUrl
 
 Resources:
   # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Resolves #151.

Replaces hardcoded `https://app.pawprintprofile.com` URLs with the
`APP_BASE_URL` environment variable, resolved dynamically at deploy time.

## Changes

- `search-handler.ts` and `search-service.ts`: messageUrl uses env var
- SAM template: new `AppBaseUrl` parameter (defaults to localhost:8080)
- `build-and-deploy.sh`: auto-resolves CloudFront URL from frontend
  stack outputs and passes it as parameter — no domain in the repo