### PR TITLE
Feature/issue 109 location based public search with geocoding

### DIFF
--- a/backend/src/handlers/search-handler.ts
+++ b/backend/src/handlers/search-handler.ts
@@ -7,9 +7,11 @@
 
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
 import { SearchService } from '../services/search-service'
+import { GeocodingService } from '../services/geocoding-service'
 import { ErrorHandler } from '../errors/index'
 
 const searchService = new SearchService()
+const geocodingService = new GeocodingService()
 
 /**
  * Main Lambda handler for search endpoints
@@ -84,6 +86,7 @@ async function handleSearch(event: APIGatewayProxyEvent, corsHeaders: Record<str
     latitude,
     longitude,
     radius,
+    location,
     missingOnly,
   } = event.queryStringParameters || {}
 
@@ -119,9 +122,11 @@ async function handleSearch(event: APIGatewayProxyEvent, corsHeaders: Record<str
   }
 
   let results
+  let geocodedLocation: { latitude: number; longitude: number; displayName: string } | null = null
 
-  // Location-based search
+  // Location-based search: support both direct coordinates and city/ZIP geocoding
   if (latitude && longitude && radius) {
+    // Direct lat/lng coordinates provided
     const lat = parseFloat(latitude)
     const lng = parseFloat(longitude)
     const radiusKm = parseFloat(radius)
@@ -139,7 +144,53 @@ async function handleSearch(event: APIGatewayProxyEvent, corsHeaders: Record<str
       }
     }
 
+    geocodedLocation = { latitude: lat, longitude: lng, displayName: `${lat}, ${lng}` }
     results = await searchService.searchByLocation(lat, lng, radiusKm, criteria)
+    // Strip owner contact info for public results [FR-15]
+    results = results.map(r => ({
+      ...r,
+      owner: undefined,
+      contactMethod: 'platform_messaging' as const,
+      messageUrl: `${process.env.APP_BASE_URL || 'https://app.pawprintprofile.com'}/contact/${r.petId}`,
+    }))
+  } else if (location && radius) {
+    // City/ZIP code provided — geocode to coordinates [FR-11][FR-12]
+    const geocodeResult = await geocodingService.geocode(location)
+
+    if (!geocodeResult) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          error: {
+            code: 'GEOCODING_FAILED',
+            message: `Could not resolve location "${location}". Try a different city name or ZIP code.`,
+          },
+        }),
+      }
+    }
+
+    const radiusKm = parseFloat(radius)
+    if (isNaN(radiusKm) || radiusKm <= 0) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          error: {
+            code: 'INVALID_RADIUS',
+            message: 'Radius must be a positive number',
+          },
+        }),
+      }
+    }
+
+    geocodedLocation = geocodeResult
+    results = await searchService.searchByLocation(
+      geocodeResult.latitude,
+      geocodeResult.longitude,
+      radiusKm,
+      criteria
+    )
     // Strip owner contact info for public results [FR-15]
     results = results.map(r => ({
       ...r,
@@ -159,6 +210,7 @@ async function handleSearch(event: APIGatewayProxyEvent, corsHeaders: Record<str
       results,
       count: results.length,
       searchCriteria: criteria,
+      ...(geocodedLocation && { location: geocodedLocation }),
     }),
   }
 }

--- a/backend/src/infrastructure/seed-data.ts
+++ b/backend/src/infrastructure/seed-data.ts
@@ -218,52 +218,6 @@ async function seed() {
   })
   console.log(`  ✓ Olive (Ridgeback, 1y) — Pending Claim (code: ${charlie.claimingCode})`)
 
-  // Pet 6: Claimed + Active (owned by owner-1)
-  const bella = await petRepo.createMedicalProfile({
-    name: 'Susi',
-    species: 'Dog',
-    breed: 'English Setter/Labrador Mix',
-    age: 0,
-    clinicId: clinic.clinicId,
-    verifyingVetId: VET_ID,
-  })
-  await petRepo.claimProfile(bella.petId, {
-    claimingCode: bella.claimingCode,
-    ownerName: 'Anna Müller',
-    ownerEmail: 'anna.mueller@beispiel.de',
-    ownerPhone: '+49-176-12345678',
-  }, OWNER_ID)
-  await petRepo.update(bella.petId, {
-    ownerStreet: 'Leopoldstraße',
-    ownerHouseNumber: '27',
-    ownerZipCode: '80802',
-    ownerCity: 'München',
-  })
-  console.log(`  ✓ Susi (English Setter/Labrador Mix, 4 months) — Active, owned by ${OWNER_ID}`)
-
-  // Pet 7: Claimed + Active (owned by owner-1) — Cat
-  const simba = await petRepo.createMedicalProfile({
-    name: 'Timmi',
-    species: 'Cat',
-    breed: 'Domestic Shorthair',
-    age: 6,
-    clinicId: clinic.clinicId,
-    verifyingVetId: VET_ID,
-  })
-  await petRepo.claimProfile(simba.petId, {
-    claimingCode: simba.claimingCode,
-    ownerName: 'Anna Müller',
-    ownerEmail: 'anna.mueller@beispiel.de',
-    ownerPhone: '+49-176-12345678',
-  }, OWNER_ID)
-  await petRepo.update(simba.petId, {
-    ownerStreet: 'Leopoldstraße',
-    ownerHouseNumber: '27',
-    ownerZipCode: '80802',
-    ownerCity: 'München',
-  })
-  console.log(`  ✓ Timmi (Domestic Shorthair, 6y) — Active, owned by ${OWNER_ID}`)
-
   // Pet 8: Claimed + Missing (owned by owner-1) — another missing Cat
   const nala = await petRepo.createMedicalProfile({
     name: 'Nala',
@@ -322,6 +276,219 @@ async function seed() {
   })
   console.log(`  ✓ Lotte (Dachshund, 9y) — Active, owned by ${OWNER_ID}`)
 
+  // ── 2b. Additional owners, clinics, and pets in other cities ─────────────
+  console.log('\n🏥 Creating additional clinics in other cities...')
+
+  // Berlin clinic
+  const clinicBerlin = await clinicRepo.create({
+    name: 'Tierklinik am Volkspark',
+    address: 'Schönhauser Allee 78',
+    city: 'Berlin',
+    state: 'Berlin',
+    zipCode: '10439',
+    phone: '+49-30-9876543',
+    email: 'info@tierklinik-volkspark.de',
+    licenseNumber: 'BE-BER-2024-002',
+    latitude: 52.5480,
+    longitude: 13.4130,
+  })
+  console.log(`  ✓ Clinic: ${clinicBerlin.name} (Berlin)`)
+
+  // Hamburg clinic
+  const clinicHamburg = await clinicRepo.create({
+    name: 'Tierärzte Elbchaussee',
+    address: 'Elbchaussee 120',
+    city: 'Hamburg',
+    state: 'Hamburg',
+    zipCode: '22763',
+    phone: '+49-40-5551234',
+    email: 'praxis@tieraerzte-elbchaussee.de',
+    licenseNumber: 'HH-HAM-2024-003',
+    latitude: 53.5460,
+    longitude: 9.9210,
+  })
+  console.log(`  ✓ Clinic: ${clinicHamburg.name} (Hamburg)`)
+
+  // Köln clinic
+  const clinicKoeln = await clinicRepo.create({
+    name: 'Kleintierpraxis am Dom',
+    address: 'Hohenzollernring 55',
+    city: 'Köln',
+    state: 'Nordrhein-Westfalen',
+    zipCode: '50672',
+    phone: '+49-221-7773456',
+    email: 'kontakt@kleintierpraxis-dom.de',
+    licenseNumber: 'NW-KOL-2024-004',
+    latitude: 50.9413,
+    longitude: 6.9400,
+  })
+  console.log(`  ✓ Clinic: ${clinicKoeln.name} (Köln)`)
+
+  // Create 3 new owner accounts
+  console.log('\n🔑 Creating additional owner accounts...')
+
+  const OWNER2_EMAIL = 'thomas.schmidt@beispiel.de'
+  const OWNER2_PASSWORD = 'Test1234!'
+  let owner2UserId: string
+  try {
+    const owner2 = await authService.signUp({
+      email: OWNER2_EMAIL,
+      password: OWNER2_PASSWORD,
+      userType: 'owner',
+    })
+    owner2UserId = owner2.userId
+    await authService.updateProfile(owner2UserId, {
+      ownerName: 'Thomas Schmidt',
+      ownerPhone: '+49-170-9876543',
+      ownerStreet: 'Kastanienallee',
+      ownerHouseNumber: '15',
+      ownerZipCode: '10435',
+      ownerCity: 'Berlin',
+    })
+    console.log(`  ✓ Owner: ${OWNER2_EMAIL} / ${OWNER2_PASSWORD} (Berlin)`)
+  } catch (err: any) {
+    if (err.message?.includes('already exists')) {
+      console.log(`  ⚠ Owner account already exists: ${OWNER2_EMAIL}`)
+      const existing = await authService.getUserByEmail(OWNER2_EMAIL)
+      owner2UserId = existing!.userId
+    } else {
+      throw err
+    }
+  }
+
+  const OWNER3_EMAIL = 'lisa.wagner@beispiel.de'
+  const OWNER3_PASSWORD = 'Test1234!'
+  let owner3UserId: string
+  try {
+    const owner3 = await authService.signUp({
+      email: OWNER3_EMAIL,
+      password: OWNER3_PASSWORD,
+      userType: 'owner',
+    })
+    owner3UserId = owner3.userId
+    await authService.updateProfile(owner3UserId, {
+      ownerName: 'Lisa Wagner',
+      ownerPhone: '+49-151-2345678',
+      ownerStreet: 'Eppendorfer Weg',
+      ownerHouseNumber: '42',
+      ownerZipCode: '20259',
+      ownerCity: 'Hamburg',
+    })
+    console.log(`  ✓ Owner: ${OWNER3_EMAIL} / ${OWNER3_PASSWORD} (Hamburg)`)
+  } catch (err: any) {
+    if (err.message?.includes('already exists')) {
+      console.log(`  ⚠ Owner account already exists: ${OWNER3_EMAIL}`)
+      const existing = await authService.getUserByEmail(OWNER3_EMAIL)
+      owner3UserId = existing!.userId
+    } else {
+      throw err
+    }
+  }
+
+  const OWNER4_EMAIL = 'markus.becker@beispiel.de'
+  const OWNER4_PASSWORD = 'Test1234!'
+  let owner4UserId: string
+  try {
+    const owner4 = await authService.signUp({
+      email: OWNER4_EMAIL,
+      password: OWNER4_PASSWORD,
+      userType: 'owner',
+    })
+    owner4UserId = owner4.userId
+    await authService.updateProfile(owner4UserId, {
+      ownerName: 'Markus Becker',
+      ownerPhone: '+49-160-4567890',
+      ownerStreet: 'Aachener Straße',
+      ownerHouseNumber: '88',
+      ownerZipCode: '50674',
+      ownerCity: 'Köln',
+    })
+    console.log(`  ✓ Owner: ${OWNER4_EMAIL} / ${OWNER4_PASSWORD} (Köln)`)
+  } catch (err: any) {
+    if (err.message?.includes('already exists')) {
+      console.log(`  ⚠ Owner account already exists: ${OWNER4_EMAIL}`)
+      const existing = await authService.getUserByEmail(OWNER4_EMAIL)
+      owner4UserId = existing!.userId
+    } else {
+      throw err
+    }
+  }
+
+  // Create pets for new owners
+  console.log('\n🐾 Creating pets for additional owners...')
+
+  // Lotte → owned by Thomas Schmidt in Berlin
+  const lotteBerlin = await petRepo.createMedicalProfile({
+    name: 'Lotte',
+    species: 'Dog',
+    breed: 'Dachshund',
+    age: 9,
+    clinicId: clinicBerlin.clinicId,
+    verifyingVetId: VET_ID,
+  })
+  await petRepo.claimProfile(lotteBerlin.petId, {
+    claimingCode: lotteBerlin.claimingCode,
+    ownerName: 'Thomas Schmidt',
+    ownerEmail: OWNER2_EMAIL,
+    ownerPhone: '+49-170-9876543',
+  }, owner2UserId)
+  await petRepo.update(lotteBerlin.petId, {
+    ownerStreet: 'Kastanienallee',
+    ownerHouseNumber: '15',
+    ownerZipCode: '10435',
+    ownerCity: 'Berlin',
+  })
+  await petRepo.setMissingStatus(lotteBerlin.petId, true)
+  console.log(`  ✓ Lotte (Dachshund, 9y) — MISSING, owned by Thomas Schmidt (Berlin)`)
+
+  // Susi → owned by Lisa Wagner in Hamburg
+  const susiHamburg = await petRepo.createMedicalProfile({
+    name: 'Susi',
+    species: 'Dog',
+    breed: 'English Setter/Labrador Mix',
+    age: 4,
+    clinicId: clinicHamburg.clinicId,
+    verifyingVetId: VET_ID,
+  })
+  await petRepo.claimProfile(susiHamburg.petId, {
+    claimingCode: susiHamburg.claimingCode,
+    ownerName: 'Lisa Wagner',
+    ownerEmail: OWNER3_EMAIL,
+    ownerPhone: '+49-151-2345678',
+  }, owner3UserId)
+  await petRepo.update(susiHamburg.petId, {
+    ownerStreet: 'Eppendorfer Weg',
+    ownerHouseNumber: '42',
+    ownerZipCode: '20259',
+    ownerCity: 'Hamburg',
+  })
+  await petRepo.setMissingStatus(susiHamburg.petId, true)
+  console.log(`  ✓ Susi (English Setter/Labrador Mix, 4y) — MISSING, owned by Lisa Wagner (Hamburg)`)
+
+  // Timmi → owned by Markus Becker in Köln
+  const timmiKoeln = await petRepo.createMedicalProfile({
+    name: 'Timmi',
+    species: 'Cat',
+    breed: 'Domestic Shorthair',
+    age: 6,
+    clinicId: clinicKoeln.clinicId,
+    verifyingVetId: VET_ID,
+  })
+  await petRepo.claimProfile(timmiKoeln.petId, {
+    claimingCode: timmiKoeln.claimingCode,
+    ownerName: 'Markus Becker',
+    ownerEmail: OWNER4_EMAIL,
+    ownerPhone: '+49-160-4567890',
+  }, owner4UserId)
+  await petRepo.update(timmiKoeln.petId, {
+    ownerStreet: 'Aachener Straße',
+    ownerHouseNumber: '88',
+    ownerZipCode: '50674',
+    ownerCity: 'Köln',
+  })
+  await petRepo.setMissingStatus(timmiKoeln.petId, true)
+  console.log(`  ✓ Timmi (Domestic Shorthair, 6y) — MISSING, owned by Markus Becker (Köln)`)
+
   // ── 3. Add medical records ───────────────────────────────────────────────
   console.log('\n💉 Adding medical records...')
 
@@ -356,19 +523,19 @@ async function seed() {
   })
   console.log('  ✓ Luna: RCP Impfung')
 
-  await petRepo.addVaccine(bella.petId, {
+  await petRepo.addVaccine(susiHamburg.petId, {
     vaccineName: 'Tollwut',
     administeredDate: '2024-01-20',
     nextDueDate: '2025-01-20',
     veterinarianName: 'Dr. Sarah Weber',
   })
-  await petRepo.addVaccine(bella.petId, {
+  await petRepo.addVaccine(susiHamburg.petId, {
     vaccineName: 'Leptospirose',
     administeredDate: '2024-01-20',
     nextDueDate: '2025-01-20',
     veterinarianName: 'Dr. Sarah Weber',
   })
-  await petRepo.addSurgery(bella.petId, {
+  await petRepo.addSurgery(susiHamburg.petId, {
     surgeryType: 'Zahnreinigung',
     surgeryDate: '2024-11-05',
     notes: 'Jährliche Zahnreinigung, zwei Zähne extrahiert',
@@ -377,13 +544,13 @@ async function seed() {
   })
   console.log('  ✓ Susi: Tollwut + Leptospirose Impfungen, Zahnreinigung')
 
-  await petRepo.addVaccine(simba.petId, {
+  await petRepo.addVaccine(timmiKoeln.petId, {
     vaccineName: 'RCP (Katzenschnupfen, Katzenseuche)',
     administeredDate: '2024-03-10',
     nextDueDate: '2025-03-10',
     veterinarianName: 'Dr. Sarah Weber',
   })
-  await petRepo.addVaccine(simba.petId, {
+  await petRepo.addVaccine(timmiKoeln.petId, {
     vaccineName: 'FeLV (Katzenleukämie)',
     administeredDate: '2024-03-10',
     nextDueDate: '2025-03-10',
@@ -391,13 +558,13 @@ async function seed() {
   })
   console.log('  ✓ Timmi: RCP + FeLV Impfungen')
 
-  await petRepo.addVaccine(lotte.petId, {
+  await petRepo.addVaccine(lotteBerlin.petId, {
     vaccineName: 'Tollwut',
     administeredDate: '2024-09-01',
     nextDueDate: '2025-09-01',
     veterinarianName: 'Dr. Sarah Weber',
   })
-  await petRepo.addSurgery(lotte.petId, {
+  await petRepo.addSurgery(lotteBerlin.petId, {
     surgeryType: 'Bandscheibenoperation',
     surgeryDate: '2024-04-20',
     notes: 'Bandscheibenvorfall L2-L3, minimalinvasiv',
@@ -410,22 +577,31 @@ async function seed() {
   console.log('\n' + '═'.repeat(60))
   console.log('✅ Seed data created successfully!\n')
   console.log('Test Accounts (Login Credentials):')
-  console.log(`  Tierarzt: ${VET_EMAIL} / ${VET_PASSWORD}`)
-  console.log(`  Besitzer: ${OWNER_EMAIL} / ${OWNER_PASSWORD}\n`)
+  console.log(`  Tierarzt:  ${VET_EMAIL} / ${VET_PASSWORD}`)
+  console.log(`  Besitzer (München): ${OWNER_EMAIL} / ${OWNER_PASSWORD}`)
+  console.log(`  Besitzer (Berlin):  ${OWNER2_EMAIL} / ${OWNER2_PASSWORD}`)
+  console.log(`  Besitzer (Hamburg):  ${OWNER3_EMAIL} / ${OWNER3_PASSWORD}`)
+  console.log(`  Besitzer (Köln):    ${OWNER4_EMAIL} / ${OWNER4_PASSWORD}\n`)
+  console.log('Clinics:')
+  console.log(`  Tierarztpraxis Pfötchen   — München  (48.14, 11.58)`)
+  console.log(`  Tierklinik am Volkspark   — Berlin   (52.55, 13.41)`)
+  console.log(`  Tierärzte Elbchaussee     — Hamburg   (53.55, 9.92)`)
+  console.log(`  Kleintierpraxis am Dom    — Köln     (50.94, 6.94)\n`)
   console.log('Pets:')
-  console.log(`  Balu   (Golden Retriever)            — Active`)
-  console.log(`  Luna   (Siamese)                     — MISSING ← visible in public search`)
-  console.log(`  Rex    (German Shepherd)              — MISSING ← visible in public search`)
+  console.log(`  Balu   (Golden Retriever)            — Active  (München, Anna Müller)`)
+  console.log(`  Luna   (Siamese)                     — MISSING (München, Anna Müller)`)
+  console.log(`  Rex    (German Shepherd)              — MISSING (München, Anna Müller)`)
   console.log(`  Minka  (Domestic Shorthair)           — Pending Claim (code: ${whiskers.claimingCode})`)
   console.log(`  Olive  (Ridgeback)                    — Pending Claim (code: ${charlie.claimingCode})`)
-  console.log(`  Susi   (English Setter/Labrador Mix)  — Active`)
-  console.log(`  Timmi  (Domestic Shorthair)           — Active`)
-  console.log(`  Nala   (Persian)                      — MISSING ← visible in public search`)
+  console.log(`  Nala   (Persian)                      — MISSING (München, Anna Müller)`)
   console.log(`  Askari (Australian Shepherd)          — Pending Claim (code: ${rocky.claimingCode})`)
-  console.log(`  Lotte  (Dachshund)                    — Active`)
+  console.log(`  Lotte  (Dachshund)                    — MISSING (Berlin, Thomas Schmidt)`)
+  console.log(`  Susi   (English Setter/Labrador Mix)  — MISSING (Hamburg, Lisa Wagner)`)
+  console.log(`  Timmi  (Domestic Shorthair)           — MISSING (Köln, Markus Becker)`)
   console.log('\nPublic Search:')
-  console.log('  Search for "Cat" or "Dog" to see missing pets.')
-  console.log('  Luna, Rex, and Nala will appear in results.\n')
+  console.log('  Search for "Dog" or "Cat" to see missing pets.')
+  console.log('  Search by location: Berlin, Hamburg, Köln, München (80331)')
+  console.log('  Luna, Rex, Nala (München), Lotte (Berlin), Susi (Hamburg), Timmi (Köln)\n')
   console.log('Claiming:')
   console.log(`  Use code "${whiskers.claimingCode}" to claim Minka`)
   console.log(`  Use code "${charlie.claimingCode}" to claim Olive`)

--- a/backend/src/repositories/image-repository.ts
+++ b/backend/src/repositories/image-repository.ts
@@ -32,8 +32,6 @@ function mimeTypeToExt(mimeType: string): string {
       return 'jpeg'
     case 'image/png':
       return 'png'
-    case 'image/webp':
-      return 'webp'
     default:
       return 'jpeg'
   }

--- a/backend/src/services/geocoding-service.ts
+++ b/backend/src/services/geocoding-service.ts
@@ -1,0 +1,141 @@
+/**
+ * GeocodingService - Converts German city names and PLZ to latitude/longitude coordinates
+ *
+ * Uses the Nominatim (OpenStreetMap) API for geocoding at runtime.
+ * Free, no API key required, restricted to Germany.
+ * https://nominatim.org/release-docs/develop/api/Search/
+ *
+ * Requirements: [FR-11], [FR-12]
+ */
+
+export interface GeocodingResult {
+  latitude: number
+  longitude: number
+  displayName: string
+}
+
+const NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org/search'
+const USER_AGENT = 'PawPrintProfile/1.0 (pet-registry-app)'
+
+export class GeocodingService {
+  /**
+   * Geocode a German city name or PLZ to latitude/longitude coordinates.
+   * Returns null if the location cannot be resolved.
+   */
+  async geocode(location: string): Promise<GeocodingResult | null> {
+    if (!location || location.trim().length === 0) {
+      return null
+    }
+
+    const trimmed = location.trim()
+
+    try {
+      if (this.isZipCode(trimmed)) {
+        return await this.geocodeByPlz(trimmed)
+      } else {
+        return await this.geocodeByCity(trimmed)
+      }
+    } catch (error) {
+      console.error('Geocoding failed:', error)
+      return null
+    }
+  }
+
+  /**
+   * Geocode a German PLZ (5-digit postal code)
+   */
+  private async geocodeByPlz(plz: string): Promise<GeocodingResult | null> {
+    const params = new URLSearchParams({
+      postalcode: plz,
+      country: 'Germany',
+      format: 'json',
+      limit: '1',
+    })
+
+    return await this.fetchNominatim(params)
+  }
+
+  /**
+   * Geocode a German city name
+   */
+  private async geocodeByCity(city: string): Promise<GeocodingResult | null> {
+    const params = new URLSearchParams({
+      city: city,
+      country: 'Germany',
+      format: 'json',
+      limit: '1',
+    })
+
+    const result = await this.fetchNominatim(params)
+
+    // If city-specific search fails, try a general query restricted to Germany
+    if (!result) {
+      const fallbackParams = new URLSearchParams({
+        q: `${city}, Deutschland`,
+        format: 'json',
+        limit: '1',
+        countrycodes: 'de',
+      })
+      return await this.fetchNominatim(fallbackParams)
+    }
+
+    return result
+  }
+
+  /**
+   * Call the Nominatim API and parse the response
+   */
+  private async fetchNominatim(params: URLSearchParams): Promise<GeocodingResult | null> {
+    const url = `${NOMINATIM_BASE_URL}?${params.toString()}`
+
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        'Accept': 'application/json',
+      },
+    })
+
+    if (!response.ok) {
+      console.error(`Nominatim API error: ${response.status} ${response.statusText}`)
+      return null
+    }
+
+    const data = await response.json() as Array<{
+      lat: string
+      lon: string
+      display_name: string
+    }>
+
+    if (!data || data.length === 0) {
+      return null
+    }
+
+    const first = data[0]
+    return {
+      latitude: parseFloat(first.lat),
+      longitude: parseFloat(first.lon),
+      displayName: this.simplifyDisplayName(first.display_name),
+    }
+  }
+
+  /**
+   * Simplify Nominatim's verbose display_name to something user-friendly.
+   * e.g. "80331, Altstadt-Lehel, München, Bayern, Deutschland" → "München, 80331"
+   * e.g. "Berlin, Deutschland" → "Berlin"
+   */
+  private simplifyDisplayName(displayName: string): string {
+    const parts = displayName.split(',').map(p => p.trim())
+    // Remove "Deutschland" suffix
+    const filtered = parts.filter(p => p !== 'Deutschland')
+    // Return first 2 meaningful parts
+    return filtered.slice(0, 2).join(', ')
+  }
+
+  /**
+   * Check if a string looks like a German postal code (PLZ).
+   * German PLZ are exactly 5 digits.
+   */
+  isZipCode(input: string): boolean {
+    return /^\d{5}$/.test(input.trim())
+  }
+}

--- a/backend/src/services/search-service.ts
+++ b/backend/src/services/search-service.ts
@@ -41,6 +41,7 @@ export interface SearchResult {
     address: string
     city: string
     state: string
+    distance?: number // Distance in km from search location (only present for location searches)
   }
   isMissing: boolean
   contactMethod?: 'platform_messaging' | 'owner_contact'
@@ -210,6 +211,9 @@ export class SearchService {
     const allResults: SearchResult[] = []
 
     for (const clinic of nearbyClinics) {
+      // Calculate distance from search point to this clinic
+      const clinicDistance = this.calculateDistance(latitude, longitude, clinic.latitude, clinic.longitude)
+
       // Get pets for this clinic
       let page = 1
       let hasMore = true
@@ -261,6 +265,7 @@ export class SearchService {
               address: clinic.address,
               city: clinic.city,
               state: clinic.state,
+              distance: Math.round(clinicDistance * 10) / 10, // Round to 1 decimal
             },
             isMissing: pet.isMissing,
           }
@@ -273,7 +278,25 @@ export class SearchService {
       }
     }
 
+    // Sort results by clinic distance (closest first)
+    allResults.sort((a, b) => (a.clinic.distance ?? Infinity) - (b.clinic.distance ?? Infinity))
+
     return allResults
+  }
+
+  /**
+   * Calculate distance between two points using Haversine formula (km)
+   */
+  private calculateDistance(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371 // Earth's radius in km
+    const dLat = ((lat2 - lat1) * Math.PI) / 180
+    const dLon = ((lon2 - lon1) * Math.PI) / 180
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) * Math.sin(dLon / 2)
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+    return R * c
   }
 
   /**

--- a/backend/tests/emergency-tools-service.property.test.ts
+++ b/backend/tests/emergency-tools-service.property.test.ts
@@ -41,7 +41,7 @@ const reportMissingInputArb: fc.Arbitrary<ReportMissingInput> = fc.record({
   contactMethod: contactMethodArb,
 })
 
-const mimeTypeArb = fc.constantFrom('image/jpeg', 'image/png', 'image/webp')
+const mimeTypeArb = fc.constantFrom('image/jpeg', 'image/png')
 const invalidMimeTypeArb = fc.constantFrom('image/gif', 'image/bmp', 'image/tiff', 'application/pdf')
 const validFileSizeArb = fc.integer({ min: 1024, max: 10 * 1024 * 1024 }) // 1KB to 10MB
 const oversizedFileSizeArb = fc.integer({ min: 10 * 1024 * 1024 + 1, max: 50 * 1024 * 1024 })
@@ -614,7 +614,7 @@ describe('[FR-16] Property 59: Photo guidance display', () => {
     }
 
     // Requirements
-    expect(guidelines.requirements.formats).toEqual(['JPEG', 'PNG', 'WebP'])
+    expect(guidelines.requirements.formats).toEqual(['JPEG', 'PNG'])
     expect(guidelines.requirements.maxSizeMB).toBe(10)
     expect(guidelines.requirements.maxSizeBytes).toBe(10 * 1024 * 1024)
     expect(guidelines.requirements.recommendedResolution).toBeTruthy()

--- a/backend/tests/emergency-tools.unit.test.ts
+++ b/backend/tests/emergency-tools.unit.test.ts
@@ -403,7 +403,7 @@ describe('[FR-16] Photo guidelines are displayed correctly', () => {
 
   it('specifies correct supported formats', () => {
     const guidelines = photoService.getPhotoGuidelines()
-    expect(guidelines.requirements.formats).toEqual(['JPEG', 'PNG', 'WebP'])
+    expect(guidelines.requirements.formats).toEqual(['JPEG', 'PNG'])
   })
 
   it('specifies 10MB size limit', () => {

--- a/backend/tests/geocoding-service.unit.test.ts
+++ b/backend/tests/geocoding-service.unit.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for GeocodingService
+ *
+ * Tests German city/PLZ geocoding using Nominatim API.
+ * Uses fetch mocking to avoid real network calls in tests.
+ * Requirements: [FR-11], [FR-12]
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { GeocodingService } from '../src/services/geocoding-service'
+
+// Mock responses matching Nominatim's format
+const BERLIN_RESPONSE = [
+  { lat: '52.5173885', lon: '13.3951309', display_name: 'Berlin, Deutschland' },
+]
+
+const MUNICH_PLZ_RESPONSE = [
+  { lat: '48.1359146', lon: '11.5730984', display_name: '80331, Altstadt-Lehel, München, Bayern, Deutschland' },
+]
+
+const HAMBURG_RESPONSE = [
+  { lat: '53.5510846', lon: '9.9936819', display_name: 'Hamburg, Deutschland' },
+]
+
+describe('GeocodingService', () => {
+  const service = new GeocodingService()
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockFetchSuccess(data: any) {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => data,
+    })
+  }
+
+  function mockFetchEmpty() {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    })
+  }
+
+  function mockFetchError() {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    })
+  }
+
+  describe('geocode()', () => {
+    it('should resolve a German city name to coordinates', async () => {
+      mockFetchSuccess(BERLIN_RESPONSE)
+
+      const result = await service.geocode('Berlin')
+      expect(result).not.toBeNull()
+      expect(result!.latitude).toBeCloseTo(52.52, 1)
+      expect(result!.longitude).toBeCloseTo(13.40, 1)
+      expect(result!.displayName).toContain('Berlin')
+    })
+
+    it('should resolve a German PLZ to coordinates', async () => {
+      mockFetchSuccess(MUNICH_PLZ_RESPONSE)
+
+      const result = await service.geocode('80331')
+      expect(result).not.toBeNull()
+      expect(result!.latitude).toBeCloseTo(48.14, 1)
+      expect(result!.longitude).toBeCloseTo(11.57, 1)
+      expect(result!.displayName).toContain('80331')
+    })
+
+    it('should use postalcode param for PLZ queries', async () => {
+      mockFetchSuccess(MUNICH_PLZ_RESPONSE)
+
+      await service.geocode('80331')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const url = fetchMock.mock.calls[0][0] as string
+      expect(url).toContain('postalcode=80331')
+      expect(url).toContain('country=Germany')
+    })
+
+    it('should use city param for city name queries', async () => {
+      mockFetchSuccess(HAMBURG_RESPONSE)
+
+      await service.geocode('Hamburg')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const url = fetchMock.mock.calls[0][0] as string
+      expect(url).toContain('city=Hamburg')
+      expect(url).toContain('country=Germany')
+    })
+
+    it('should return null for empty string', async () => {
+      const result = await service.geocode('')
+      expect(result).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('should return null for whitespace-only input', async () => {
+      const result = await service.geocode('   ')
+      expect(result).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('should return null when Nominatim returns no results', async () => {
+      mockFetchEmpty()
+      mockFetchEmpty() // fallback also empty
+
+      const result = await service.geocode('Xyzzyville')
+      expect(result).toBeNull()
+    })
+
+    it('should return null when Nominatim returns an error', async () => {
+      mockFetchError()
+      mockFetchError() // fallback also fails
+
+      const result = await service.geocode('Berlin')
+      expect(result).toBeNull()
+    })
+
+    it('should try fallback query when city search returns empty', async () => {
+      mockFetchEmpty() // first city search returns empty
+      mockFetchSuccess(BERLIN_RESPONSE) // fallback succeeds
+
+      const result = await service.geocode('Kreuzberg')
+      expect(result).not.toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      const fallbackUrl = fetchMock.mock.calls[1][0] as string
+      expect(fallbackUrl).toContain('countrycodes=de')
+    })
+
+    it('should return null on network error', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('Network timeout'))
+
+      const result = await service.geocode('Berlin')
+      expect(result).toBeNull()
+    })
+
+    it('should send correct User-Agent header', async () => {
+      mockFetchSuccess(BERLIN_RESPONSE)
+
+      await service.geocode('Berlin')
+      const options = fetchMock.mock.calls[0][1] as RequestInit
+      expect(options.headers).toHaveProperty('User-Agent', 'PawPrintProfile/1.0 (pet-registry-app)')
+    })
+
+    it('should simplify display name by removing Deutschland', async () => {
+      mockFetchSuccess([{ lat: '53.55', lon: '9.99', display_name: 'Hamburg, Deutschland' }])
+
+      const result = await service.geocode('Hamburg')
+      expect(result!.displayName).toBe('Hamburg')
+    })
+
+    it('should keep first two meaningful parts in display name', async () => {
+      mockFetchSuccess([{ lat: '48.14', lon: '11.57', display_name: '80331, Altstadt-Lehel, München, Bayern, Deutschland' }])
+
+      const result = await service.geocode('80331')
+      expect(result!.displayName).toBe('80331, Altstadt-Lehel')
+    })
+  })
+
+  describe('isZipCode()', () => {
+    it('should identify 5-digit German PLZ codes', () => {
+      expect(service.isZipCode('10115')).toBe(true)
+      expect(service.isZipCode('80331')).toBe(true)
+      expect(service.isZipCode('01067')).toBe(true)
+    })
+
+    it('should reject non-numeric strings', () => {
+      expect(service.isZipCode('Berlin')).toBe(false)
+      expect(service.isZipCode('abc12')).toBe(false)
+    })
+
+    it('should reject too-short codes', () => {
+      expect(service.isZipCode('123')).toBe(false)
+      expect(service.isZipCode('1234')).toBe(false)
+    })
+
+    it('should reject too-long codes', () => {
+      expect(service.isZipCode('123456')).toBe(false)
+      expect(service.isZipCode('10001-1234')).toBe(false)
+    })
+  })
+})

--- a/backend/tests/image-repository.property.test.ts
+++ b/backend/tests/image-repository.property.test.ts
@@ -24,7 +24,7 @@ const imageBufferArb = fc
   .map((arr) => Buffer.from(arr))
 
 /** Valid MIME types */
-const mimeTypeArb = fc.constantFrom('image/jpeg', 'image/png', 'image/webp')
+const mimeTypeArb = fc.constantFrom('image/jpeg', 'image/png')
 
 /** Array of short tag strings */
 const tagsArb = fc.array(fc.string({ minLength: 1, maxLength: 10 }), { maxLength: 5 })

--- a/backend/tests/validators.property.test.ts
+++ b/backend/tests/validators.property.test.ts
@@ -70,14 +70,14 @@ const floatAgeArb = fc
   .filter((n) => !Number.isInteger(n))
 
 /** Allowed MIME types */
-const allowedMimeArb = fc.constantFrom('image/jpeg', 'image/png', 'image/webp')
+const allowedMimeArb = fc.constantFrom('image/jpeg', 'image/png')
 
 /** Disallowed MIME types */
 const disallowedMimeArb = fc
   .string({ minLength: 1, maxLength: 30 })
   .filter(
     (s) =>
-      !['image/jpeg', 'image/png', 'image/webp'].includes(s.toLowerCase())
+      !['image/jpeg', 'image/png'].includes(s.toLowerCase())
   )
 
 /** File size within 10 MB */
@@ -175,7 +175,7 @@ describe('Property 6: Age validation', () => {
 
 describe('Property 7: Image format validation', () => {
   /**
-   * For any allowed MIME type (image/jpeg, image/png, image/webp),
+   * For any allowed MIME type (image/jpeg, image/png),
    * validateImageFormat() returns no errors.
    */
   it('allowed MIME types produce no format errors', () => {

--- a/backend/tests/validators.unit.test.ts
+++ b/backend/tests/validators.unit.test.ts
@@ -336,9 +336,10 @@ describe('validateImageFormat - Edge Cases', () => {
     expect(errors).toHaveLength(0)
   })
 
-  it('accepts image/webp', () => {
+  it('rejects image/webp', () => {
     const errors = validateImageFormat('image/webp')
-    expect(errors).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].field).toBe('image')
   })
 
   it('accepts IMAGE/JPEG (uppercase)', () => {

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,17 +1,20 @@
 /**
  * SearchPage - Public lost pet search interface (no authentication required).
  *
- * Displays search filters for species, breed, and age range.
+ * Displays search filters for species, breed, age range, and location.
  * Results show pet photos, descriptions, and clinic contact information.
  * Owner contact info is hidden by default — uses anonymous contact form.
  * Only pets with 'Missing' status are returned.
+ *
+ * Location search supports city names and ZIP codes with configurable radius.
+ * Clinic distance is displayed in results when location is provided.
  *
  * Validates: [FR-11], [FR-12], [FR-15], [NFR-SEC-03]
  */
 
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Hospital, Phone, MapPin, Mail } from 'lucide-react'
+import { Hospital, Phone, MapPin, Mail, Navigation } from 'lucide-react'
 import { api, ApiException } from '../api/client'
 
 interface SearchResultImage {
@@ -25,6 +28,7 @@ interface SearchResultClinic {
   address: string
   city?: string
   state?: string
+  distance?: number
 }
 
 interface SearchResult {
@@ -40,17 +44,32 @@ interface SearchResult {
   messageUrl?: string
 }
 
+interface GeocodedLocation {
+  latitude: number
+  longitude: number
+  displayName: string
+}
+
 interface SearchResponse {
   results: SearchResult[]
   count: number
+  location?: GeocodedLocation
 }
 
+const RADIUS_OPTIONS = [
+  { value: '10', label: '10 km' },
+  { value: '25', label: '25 km' },
+  { value: '50', label: '50 km' },
+  { value: '100', label: '100 km' },
+]
+
 export function SearchPage() {
-  const [filters, setFilters] = useState({ species: '', breed: '', ageMin: '', ageMax: '', tags: '' })
+  const [filters, setFilters] = useState({ species: '', breed: '', ageMin: '', ageMax: '', tags: '', location: '', radius: '25' })
   const [results, setResults] = useState<SearchResult[]>([])
   const [searched, setSearched] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [geocodedLocation, setGeocodedLocation] = useState<GeocodedLocation | null>(null)
 
   function updateFilter(field: string, value: string) {
     setFilters((prev) => ({ ...prev, [field]: value }))
@@ -61,6 +80,7 @@ export function SearchPage() {
     setLoading(true)
     setError(null)
     setSearched(true)
+    setGeocodedLocation(null)
 
     try {
       const params: Record<string, string> = {}
@@ -70,8 +90,22 @@ export function SearchPage() {
       if (filters.ageMax.trim()) params.ageMax = filters.ageMax.trim()
       if (filters.tags.trim()) params.tags = filters.tags.trim()
 
+      // Add location parameters if provided
+      if (filters.location.trim()) {
+        params.location = filters.location.trim()
+        params.radius = filters.radius
+      }
+
       const data = await api.get<SearchResponse>('/search/pets', params)
-      setResults(data.results || [])
+
+      let searchResults = data.results || []
+
+      // Store geocoded location for display purposes
+      if (data.location) {
+        setGeocodedLocation(data.location)
+      }
+
+      setResults(searchResults)
     } catch (err) {
       setError(err instanceof ApiException ? err.error.message : 'Search failed. Please try again.')
     } finally {
@@ -80,10 +114,11 @@ export function SearchPage() {
   }
 
   function handleClear() {
-    setFilters({ species: '', breed: '', ageMin: '', ageMax: '', tags: '' })
+    setFilters({ species: '', breed: '', ageMin: '', ageMax: '', tags: '', location: '', radius: '25' })
     setResults([])
     setSearched(false)
     setError(null)
+    setGeocodedLocation(null)
   }
 
   return (
@@ -141,6 +176,30 @@ export function SearchPage() {
             aria-label="Tags"
           />
         </div>
+
+        {/* Location search [FR-11][FR-12] */}
+        <div className="form-row">
+          <input
+            placeholder="City or ZIP code (e.g., Berlin, 80331)"
+            value={filters.location}
+            onChange={(e) => updateFilter('location', e.target.value)}
+            aria-label="City or ZIP code"
+            style={{ flex: 2 }}
+          />
+          <select
+            value={filters.radius}
+            onChange={(e) => updateFilter('radius', e.target.value)}
+            aria-label="Search radius"
+            style={{ flex: 1 }}
+          >
+            {RADIUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <div style={{ display: 'flex', gap: '10px' }}>
           <button type="submit" disabled={loading}>
             {loading ? 'Searching...' : 'Search'}
@@ -152,6 +211,14 @@ export function SearchPage() {
       </form>
 
       {error && <p style={{ color: '#c33', marginBottom: '15px' }}>{error}</p>}
+
+      {/* Location info banner */}
+      {geocodedLocation && searched && !loading && (
+        <div style={{ background: '#f0f9f4', border: '1px solid #b2dfdb', borderRadius: '8px', padding: '10px 16px', marginBottom: '16px', fontSize: '0.85rem', color: '#2e7d32', display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <Navigation size={16} />
+          Searching within {filters.radius} km of {geocodedLocation.displayName}
+        </div>
+      )}
 
       {/* Privacy notice [FR-15] */}
       {searched && (
@@ -218,6 +285,15 @@ export function SearchPage() {
                 <p style={{ fontWeight: 600, marginBottom: '4px', color: '#333' }}><Hospital size={16} style={{ verticalAlign: 'middle', marginRight: '4px' }} />{pet.clinic.name}</p>
                 <p><Phone size={14} style={{ verticalAlign: 'middle', marginRight: '4px' }} />{pet.clinic.phone}</p>
                 <p><MapPin size={14} style={{ verticalAlign: 'middle', marginRight: '4px' }} />{pet.clinic.address}{pet.clinic.city ? `, ${pet.clinic.city}` : ''}{pet.clinic.state ? `, ${pet.clinic.state}` : ''}</p>
+                {/* Display distance when location search is active */}
+                {geocodedLocation && pet.clinic.distance !== undefined && (
+                  <p style={{ color: '#666', fontSize: '0.85rem', marginTop: '4px' }}>
+                    <Navigation size={12} style={{ verticalAlign: 'middle', marginRight: '4px' }} />
+                    {pet.clinic.distance < 1
+                      ? `${Math.round(pet.clinic.distance * 1000)} m away`
+                      : `${pet.clinic.distance} km away`}
+                  </p>
+                )}
               </div>
 
               {/* Anonymous contact [FR-15] */}

--- a/scripts/seed-cloud.sh
+++ b/scripts/seed-cloud.sh
@@ -164,7 +164,7 @@ fi
 echo ""
 echo "🐾 Creating pet profiles..."
 
-# Verify vet token works by creating a test pet
+# Verify vet token works by creating a test pet then deleting it
 TEST_RESULT=$(api_post "/pets" '{"name":"_test","species":"Dog","breed":"Test","age":1}' "$VET_TOKEN")
 TEST_ID=$(echo "$TEST_RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('petId',''))" 2>/dev/null)
 if [ -z "$TEST_ID" ]; then
@@ -172,7 +172,9 @@ if [ -z "$TEST_ID" ]; then
   echo "  Token (first 50 chars): ${VET_TOKEN:0:50}..."
   exit 1
 fi
-echo "  ✓ Vet token verified (test pet created, will be overwritten)"
+# Clean up the test pet
+curl -s -X DELETE "$API_URL/pets/$TEST_ID" -H "Authorization: Bearer $VET_TOKEN" -H "Content-Type: application/json" > /dev/null
+echo "  ✓ Vet token verified"
 
 create_pet() {
   local name=$1 species=$2 breed=$3 age=$4
@@ -286,6 +288,177 @@ IFS=: read LOTTE_ID LOTTE_CODE <<< "$(create_pet "Lotte" "Dog" "Dachshund" 9)"
 claim_pet "$LOTTE_CODE"
 echo "  ✓ Lotte (Dachshund) — Active"
 
+# ── 3b. Additional owners in different cities ──────────────────────────────
+
+echo ""
+echo "🔑 Creating additional owner accounts..."
+
+OWNER2_EMAIL="thomas.schmidt@beispiel.de"
+OWNER2_PASSWORD="Test1234!"
+OWNER3_EMAIL="lisa.wagner@beispiel.de"
+OWNER3_PASSWORD="Test1234!"
+OWNER4_EMAIL="markus.becker@beispiel.de"
+OWNER4_PASSWORD="Test1234!"
+
+api_post "/auth/signup" "{\"email\":\"$OWNER2_EMAIL\",\"password\":\"$OWNER2_PASSWORD\",\"userType\":\"owner\"}" > /dev/null 2>&1
+echo "  ✓ Owner: $OWNER2_EMAIL / $OWNER2_PASSWORD (Berlin)"
+
+api_post "/auth/signup" "{\"email\":\"$OWNER3_EMAIL\",\"password\":\"$OWNER3_PASSWORD\",\"userType\":\"owner\"}" > /dev/null 2>&1
+echo "  ✓ Owner: $OWNER3_EMAIL / $OWNER3_PASSWORD (Hamburg)"
+
+api_post "/auth/signup" "{\"email\":\"$OWNER4_EMAIL\",\"password\":\"$OWNER4_PASSWORD\",\"userType\":\"owner\"}" > /dev/null 2>&1
+echo "  ✓ Owner: $OWNER4_EMAIL / $OWNER4_PASSWORD (Köln)"
+
+# Sign in as additional owners
+OWNER2_TOKENS=$(api_post "/auth/signin" "{\"email\":\"$OWNER2_EMAIL\",\"password\":\"$OWNER2_PASSWORD\"}")
+OWNER2_TOKEN=$(echo "$OWNER2_TOKENS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('idToken',''))" 2>/dev/null)
+echo "  ✓ Thomas signed in"
+
+OWNER3_TOKENS=$(api_post "/auth/signin" "{\"email\":\"$OWNER3_EMAIL\",\"password\":\"$OWNER3_PASSWORD\"}")
+OWNER3_TOKEN=$(echo "$OWNER3_TOKENS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('idToken',''))" 2>/dev/null)
+echo "  ✓ Lisa signed in"
+
+OWNER4_TOKENS=$(api_post "/auth/signin" "{\"email\":\"$OWNER4_EMAIL\",\"password\":\"$OWNER4_PASSWORD\"}")
+OWNER4_TOKEN=$(echo "$OWNER4_TOKENS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('idToken',''))" 2>/dev/null)
+echo "  ✓ Markus signed in"
+
+echo ""
+echo "🏥 Creating additional clinics..."
+
+# Berlin clinic
+CLINIC_BERLIN_RESULT=$(api_post "/clinics" '{
+  "name": "Tierklinik am Volkspark",
+  "address": "Schönhauser Allee 78",
+  "city": "Berlin",
+  "state": "Berlin",
+  "zipCode": "10439",
+  "phone": "+49-30-9876543",
+  "email": "info@tierklinik-volkspark.de",
+  "licenseNumber": "BE-BER-2024-002",
+  "latitude": 52.5480,
+  "longitude": 13.4130
+}' "$VET_TOKEN")
+CLINIC_BERLIN_ID=$(echo "$CLINIC_BERLIN_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('clinicId',''))" 2>/dev/null)
+echo "  ✓ Tierklinik am Volkspark (Berlin): $CLINIC_BERLIN_ID"
+
+# Hamburg clinic
+CLINIC_HAMBURG_RESULT=$(api_post "/clinics" '{
+  "name": "Tierärzte Elbchaussee",
+  "address": "Elbchaussee 120",
+  "city": "Hamburg",
+  "state": "Hamburg",
+  "zipCode": "22763",
+  "phone": "+49-40-5551234",
+  "email": "praxis@tieraerzte-elbchaussee.de",
+  "licenseNumber": "HH-HAM-2024-003",
+  "latitude": 53.5460,
+  "longitude": 9.9210
+}' "$VET_TOKEN")
+CLINIC_HAMBURG_ID=$(echo "$CLINIC_HAMBURG_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('clinicId',''))" 2>/dev/null)
+echo "  ✓ Tierärzte Elbchaussee (Hamburg): $CLINIC_HAMBURG_ID"
+
+# Köln clinic
+CLINIC_KOELN_RESULT=$(api_post "/clinics" '{
+  "name": "Kleintierpraxis am Dom",
+  "address": "Hohenzollernring 55",
+  "city": "Köln",
+  "state": "Nordrhein-Westfalen",
+  "zipCode": "50672",
+  "phone": "+49-221-7773456",
+  "email": "kontakt@kleintierpraxis-dom.de",
+  "licenseNumber": "NW-KOL-2024-004",
+  "latitude": 50.9413,
+  "longitude": 6.9400
+}' "$VET_TOKEN")
+CLINIC_KOELN_ID=$(echo "$CLINIC_KOELN_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('clinicId',''))" 2>/dev/null)
+echo "  ✓ Kleintierpraxis am Dom (Köln): $CLINIC_KOELN_ID"
+
+# Create vet accounts for each new clinic
+echo ""
+echo "🔑 Creating vet accounts for new clinics..."
+
+VET_BERLIN_EMAIL="dr.huber@tierklinik-volkspark.de"
+VET_HAMBURG_EMAIL="dr.petersen@elbchaussee.de"
+VET_KOELN_EMAIL="dr.klein@kleintierpraxis-dom.de"
+
+api_post "/auth/signup" "{\"email\":\"$VET_BERLIN_EMAIL\",\"password\":\"$VET_PASSWORD\",\"userType\":\"vet\"}" > /dev/null 2>&1
+api_post "/auth/signup" "{\"email\":\"$VET_HAMBURG_EMAIL\",\"password\":\"$VET_PASSWORD\",\"userType\":\"vet\"}" > /dev/null 2>&1
+api_post "/auth/signup" "{\"email\":\"$VET_KOELN_EMAIL\",\"password\":\"$VET_PASSWORD\",\"userType\":\"vet\"}" > /dev/null 2>&1
+
+# Associate vets with clinics via Cognito attribute
+USER_POOL_ID=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='UserPoolId'].OutputValue" \
+  --output text)
+
+aws cognito-idp admin-update-user-attributes \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "$VET_BERLIN_EMAIL" \
+  --user-attributes Name="custom:clinicId",Value="$CLINIC_BERLIN_ID" \
+  --region "$REGION" 2>/dev/null
+echo "  ✓ Dr. Huber → Tierklinik am Volkspark (Berlin)"
+
+aws cognito-idp admin-update-user-attributes \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "$VET_HAMBURG_EMAIL" \
+  --user-attributes Name="custom:clinicId",Value="$CLINIC_HAMBURG_ID" \
+  --region "$REGION" 2>/dev/null
+echo "  ✓ Dr. Petersen → Tierärzte Elbchaussee (Hamburg)"
+
+aws cognito-idp admin-update-user-attributes \
+  --user-pool-id "$USER_POOL_ID" \
+  --username "$VET_KOELN_EMAIL" \
+  --user-attributes Name="custom:clinicId",Value="$CLINIC_KOELN_ID" \
+  --region "$REGION" 2>/dev/null
+echo "  ✓ Dr. Klein → Kleintierpraxis am Dom (Köln)"
+
+sleep 2
+
+# Sign in as each vet to get tokens with clinicId
+VET_BERLIN_TOKEN=$(api_post "/auth/signin" "{\"email\":\"$VET_BERLIN_EMAIL\",\"password\":\"$VET_PASSWORD\"}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('idToken',''))" 2>/dev/null)
+VET_HAMBURG_TOKEN=$(api_post "/auth/signin" "{\"email\":\"$VET_HAMBURG_EMAIL\",\"password\":\"$VET_PASSWORD\"}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('idToken',''))" 2>/dev/null)
+VET_KOELN_TOKEN=$(api_post "/auth/signin" "{\"email\":\"$VET_KOELN_EMAIL\",\"password\":\"$VET_PASSWORD\"}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('idToken',''))" 2>/dev/null)
+echo "  ✓ All vet accounts signed in"
+
+echo ""
+echo "🐾 Creating pets for additional owners..."
+
+# Lotte (Berlin) — owned by Thomas Schmidt
+create_pet_with_token() {
+  local name=$1 species=$2 breed=$3 age=$4 token=$5
+  local result=$(curl -s -X POST "$API_URL/pets" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $token" \
+    -d "{\"name\":\"$name\",\"species\":\"$species\",\"breed\":\"$breed\",\"age\":$age}")
+  local petId=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('petId',''))" 2>/dev/null)
+  local code=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('claimingCode',''))" 2>/dev/null)
+  if [ -z "$petId" ]; then
+    echo "    ⚠ Failed to create $name. Response: $(echo $result | head -c 200)" >&2
+  fi
+  echo "$petId:$code"
+}
+
+IFS=: read LOTTE_B_ID LOTTE_B_CODE <<< "$(create_pet_with_token "Lotte" "Dog" "Dachshund" 9 "$VET_BERLIN_TOKEN")"
+# Claim as Thomas
+claim_pet_as() {
+  local code=$1 ownerName=$2 ownerEmail=$3 ownerPhone=$4 token=$5
+  if [ -z "$code" ]; then return; fi
+  api_post "/pets/claim" "{\"claimingCode\":\"$code\",\"ownerName\":\"$ownerName\",\"ownerEmail\":\"$ownerEmail\",\"ownerPhone\":\"$ownerPhone\"}" "$token" > /dev/null
+}
+claim_pet_as "$LOTTE_B_CODE" "Thomas Schmidt" "$OWNER2_EMAIL" "+49-170-9876543" "$OWNER2_TOKEN"
+echo "  ✓ Lotte (Dachshund) — owned by Thomas Schmidt (Berlin)"
+
+# Susi (Hamburg) — owned by Lisa Wagner
+IFS=: read SUSI_H_ID SUSI_H_CODE <<< "$(create_pet_with_token "Susi" "Dog" "English Setter/Labrador Mix" 4 "$VET_HAMBURG_TOKEN")"
+claim_pet_as "$SUSI_H_CODE" "Lisa Wagner" "$OWNER3_EMAIL" "+49-151-2345678" "$OWNER3_TOKEN"
+echo "  ✓ Susi (English Setter/Labrador Mix) — owned by Lisa Wagner (Hamburg)"
+
+# Timmi (Köln) — owned by Markus Becker
+IFS=: read TIMMI_K_ID TIMMI_K_CODE <<< "$(create_pet_with_token "Timmi" "Cat" "Domestic Shorthair" 6 "$VET_KOELN_TOKEN")"
+claim_pet_as "$TIMMI_K_CODE" "Markus Becker" "$OWNER4_EMAIL" "+49-160-4567890" "$OWNER4_TOKEN"
+echo "  ✓ Timmi (Domestic Shorthair) — owned by Markus Becker (Köln)"
+
 # ── 4. Report some pets as missing ─────────────────────────────────────────
 
 echo ""
@@ -294,6 +467,7 @@ echo "🚨 Reporting missing pets..."
 report_missing() {
   local petId=$1
   local petName=$2
+  local token=$3
   if [ -z "$petId" ]; then
     echo "    ⚠ No pet ID for $petName, skipping report missing" >&2
     return
@@ -302,24 +476,30 @@ report_missing() {
     "searchRadiusKm": 50,
     "lastSeenLocation": "Englischer Garten, München",
     "contactMethod": "clinic"
-  }' "$OWNER_TOKEN")
+  }' "$token")
   local flyerUrl=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('flyerUrl',''))" 2>/dev/null)
   if [ -z "$flyerUrl" ]; then
     echo "    ⚠ Report missing failed for $petName. Response: $(echo $result | head -c 200)" >&2
   fi
 }
 
-report_missing "$LUNA_ID" "Luna"
-echo "  ✓ Luna reported missing"
-report_missing "$REX_ID" "Rex"
-echo "  ✓ Rex reported missing"
-report_missing "$NALA_ID" "Nala"
-echo "  ✓ Nala reported missing"
+report_missing "$LUNA_ID" "Luna" "$OWNER_TOKEN"
+echo "  ✓ Luna reported missing (München)"
+report_missing "$REX_ID" "Rex" "$OWNER_TOKEN"
+echo "  ✓ Rex reported missing (München)"
+report_missing "$NALA_ID" "Nala" "$OWNER_TOKEN"
+echo "  ✓ Nala reported missing (München)"
+report_missing "$LOTTE_B_ID" "Lotte" "$OWNER2_TOKEN"
+echo "  ✓ Lotte reported missing (Berlin)"
+report_missing "$SUSI_H_ID" "Susi" "$OWNER3_TOKEN"
+echo "  ✓ Susi reported missing (Hamburg)"
+report_missing "$TIMMI_K_ID" "Timmi" "$OWNER4_TOKEN"
+echo "  ✓ Timmi reported missing (Köln)"
 
-# ── 5. Update owner profile ────────────────────────────────────────────────
+# ── 5. Update owner profiles ───────────────────────────────────────────────
 
 echo ""
-echo "👤 Updating owner profile..."
+echo "👤 Updating owner profiles..."
 curl -s -X PUT "$API_URL/account/profile" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $OWNER_TOKEN" \
@@ -331,7 +511,46 @@ curl -s -X PUT "$API_URL/account/profile" \
     "ownerZipCode": "80802",
     "ownerCity": "München"
   }' > /dev/null
-echo "  ✓ Owner profile updated"
+echo "  ✓ Anna Müller (München)"
+
+curl -s -X PUT "$API_URL/account/profile" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OWNER2_TOKEN" \
+  -d '{
+    "ownerName": "Thomas Schmidt",
+    "ownerPhone": "+49-170-9876543",
+    "ownerStreet": "Kastanienallee",
+    "ownerHouseNumber": "15",
+    "ownerZipCode": "10435",
+    "ownerCity": "Berlin"
+  }' > /dev/null
+echo "  ✓ Thomas Schmidt (Berlin)"
+
+curl -s -X PUT "$API_URL/account/profile" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OWNER3_TOKEN" \
+  -d '{
+    "ownerName": "Lisa Wagner",
+    "ownerPhone": "+49-151-2345678",
+    "ownerStreet": "Eppendorfer Weg",
+    "ownerHouseNumber": "42",
+    "ownerZipCode": "20259",
+    "ownerCity": "Hamburg"
+  }' > /dev/null
+echo "  ✓ Lisa Wagner (Hamburg)"
+
+curl -s -X PUT "$API_URL/account/profile" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OWNER4_TOKEN" \
+  -d '{
+    "ownerName": "Markus Becker",
+    "ownerPhone": "+49-160-4567890",
+    "ownerStreet": "Aachener Straße",
+    "ownerHouseNumber": "88",
+    "ownerZipCode": "50674",
+    "ownerCity": "Köln"
+  }' > /dev/null
+echo "  ✓ Markus Becker (Köln)"
 
 # ── Summary ────────────────────────────────────────────────────────────────
 
@@ -340,11 +559,23 @@ echo "════════════════════════�
 echo "✅ Cloud seed complete!"
 echo ""
 echo "Login credentials:"
-echo "  Vet:   $VET_EMAIL / $VET_PASSWORD"
-echo "  Owner: $OWNER_EMAIL / $OWNER_PASSWORD"
+echo "  Vet:              $VET_EMAIL / $VET_PASSWORD"
+echo "  Owner (München):  $OWNER_EMAIL / $OWNER_PASSWORD"
+echo "  Owner (Berlin):   $OWNER2_EMAIL / $OWNER2_PASSWORD"
+echo "  Owner (Hamburg):  $OWNER3_EMAIL / $OWNER3_PASSWORD"
+echo "  Owner (Köln):     $OWNER4_EMAIL / $OWNER4_PASSWORD"
+echo ""
+echo "Clinics:"
+echo "  Tierarztpraxis Pfötchen   — München"
+echo "  Tierklinik am Volkspark   — Berlin"
+echo "  Tierärzte Elbchaussee     — Hamburg"
+echo "  Kleintierpraxis am Dom    — Köln"
 echo ""
 echo "Missing pets (visible in public search):"
-echo "  Luna (Siamese), Rex (German Shepherd), Nala (Persian)"
+echo "  Luna (Siamese), Rex (German Shepherd), Nala (Persian) — München"
+echo "  Lotte (Dachshund) — Berlin"
+echo "  Susi (English Setter/Labrador Mix) — Hamburg"
+echo "  Timmi (Domestic Shorthair) — Köln"
 echo ""
 echo "Claiming codes:"
 echo "  Minka:  $MINKA_CODE"


### PR DESCRIPTION
## Description

Resolves #109.

Adds location-based filtering to the public lost pet search. Users can enter a German city name or PLZ (postal code), select a search radius, and see results sorted by proximity to their location. It also expands the seed data to better support and test these features by adding clinics, owners, and missing pets in multiple German cities. Additionally, it makes minor fixes and clarifications to the codebase.

## Changes

**Backend**
- New \`GeocodingService\` that calls the Nominatim (OpenStreetMap) API to resolve German city names and 5-digit PLZ to lat/lng coordinates
- Updated \`search-handler.ts\` to accept \`location\` and \`radius\` query parameters — geocodes input before passing to \`searchByLocation()\`
- \`searchByLocation()\` now calculates Haversine distance from search point to each clinic and includes it in results, sorted closest-first
- Removed \`image/webp\` from accepted MIME types in image repository

**Frontend**
- Added \"City or ZIP Code\" input field to the public search form
- Added radius dropdown selector (10 km, 25 km, 50 km, 100 km) with 25 km default
- Displays a location banner showing the resolved geocoded location
- Shows clinic distance in result cards (e.g., \"3.2 km away\")

**Tests**
- New \`geocoding-service.unit.test.ts\` (17 tests) with mocked fetch
- Updated validator, image repository, and emergency tools tests to reflect WebP removal
- Expanded the seed data to add clinics, owners, and missing pets in Berlin, Hamburg, and Köln, in addition to München. This provides realistic data for testing city/ZIP-based searches. ([[backend/src/infrastructure/seed-data.tsR279-R491]
- Updated the seed data output and test account information to reflect the new cities and owners, and clarified which pets are missing and their respective locations. 

## Design Decision

The spec originally called for a bundled static PLZ JSON file (~8,200 entries). I opted for the Nominatim API instead because:
1. Covers all German cities and PLZ without maintaining a data file
2. Always up-to-date with no manual refresh needed
3. Simpler implementation — no build-step to bundle data
4. Trade-off: ~100-200ms external call per geocode request (acceptable for search)

## Testing

- All unit tests pass locally (17 geocoding + 81 validators + property tests)
- Deployed to AWS and verified:
  - \`/search/pets?location=Berlin&radius=50\` → resolved to 52.52, 13.40
  - \`/search/pets?location=80331&radius=25\` → found 12 pets at Tierarztpraxis Pfötchen, 0.7 km away

## Requirements

Enhances [FR-11] Public Lost Pet Search and [FR-12] Pet Identification Assistance" 