### PR TITLE
Feature/issue 134 photo attachment contact form

### DIFF
--- a/backend/src/handlers/emergency-tools-handler.ts
+++ b/backend/src/handlers/emergency-tools-handler.ts
@@ -76,6 +76,8 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
           return await handleReportMissing(event, user)
         } else if (path.includes('/care-snapshot')) {
           return await handleCreateCareSnapshot(event, user)
+        } else if (path.includes('/contact/upload-url')) {
+          return await handleContactUploadUrl(event) // Public — no auth required
         } else if (path.includes('/contact')) {
           return await handleContactOwner(event) // Public — no auth required
         }
@@ -332,10 +334,51 @@ async function handlePhotoGuidance(
 // Centralized via ErrorHandler.toResponse() in the catch block above.
 
 /**
+ * POST /pets/{petId}/contact/upload-url — Get pre-signed S3 PUT URL for contact image
+ * Public endpoint (no auth). Returns a pre-signed URL for the client to upload directly to S3.
+ * This bypasses the API Gateway 10MB payload limit.
+ * Requirements: [FR-12], [FR-15]
+ */
+async function handleContactUploadUrl(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  const petId = event.pathParameters?.petId
+  if (!petId) return badRequest('INVALID_INPUT', 'petId is required')
+
+  const body = event.body ? JSON.parse(event.body) : {}
+  const { mimeType } = body
+
+  if (!mimeType) {
+    return badRequest('INVALID_INPUT', 'mimeType is required')
+  }
+
+  const allowedMimeTypes = ['image/jpeg', 'image/png']
+  if (!allowedMimeTypes.includes(mimeType)) {
+    return badRequest('INVALID_INPUT', 'Image must be JPEG or PNG format')
+  }
+
+  const ext = mimeType === 'image/png' ? 'png' : 'jpg'
+  const timestamp = Date.now()
+  const s3Key = `contact-images/${petId}/${timestamp}.${ext}`
+  const bucketName = process.env.S3_BUCKET ?? process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images'
+
+  const factory = new AWSClientFactory()
+  const s3Client = factory.createS3Client()
+
+  const command = new PutObjectCommand({
+    Bucket: bucketName,
+    Key: s3Key,
+    ContentType: mimeType,
+  })
+
+  // Pre-signed PUT URL valid for 15 minutes
+  const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 900 })
+
+  return respond(200, { uploadUrl, imageKey: s3Key })
+}
+
+/**
  * POST /pets/{petId}/contact — Send anonymous message to pet owner (Public)
- * Accepts senderName, senderEmail, message, and optional imageBase64/mimeType.
- * If an image is provided, uploads to S3 under contact-images/{petId}/{timestamp}.{ext},
- * generates a 7-day pre-signed URL, and includes it in the notification.
+ * Accepts senderName, senderEmail, message, and optional imageKey (S3 key from pre-signed upload).
+ * If imageKey is provided, generates a 7-day pre-signed GET URL and includes it in the notification.
  * Requirements: [FR-12], [FR-15]
  */
 async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
@@ -343,7 +386,7 @@ async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatew
   if (!petId) return badRequest('INVALID_INPUT', 'petId is required')
 
   const body = event.body ? JSON.parse(event.body) : {}
-  const { senderName, senderEmail, message, imageBase64, mimeType } = body
+  const { senderName, senderEmail, message, imageKey } = body
 
   if (!senderName || !senderEmail || !message) {
     return badRequest('INVALID_INPUT', 'senderName, senderEmail, and message are required')
@@ -358,51 +401,21 @@ async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatew
     return badRequest('INVALID_INPUT', 'Message must be 1000 characters or less')
   }
 
-  // Validate image attachment if provided
+  // Generate a pre-signed GET URL if an image was uploaded via pre-signed PUT
   let imageUrl: string | undefined
-  if (imageBase64) {
-    if (!mimeType) {
-      return badRequest('INVALID_INPUT', 'mimeType is required when imageBase64 is provided')
+  if (imageKey) {
+    // Validate that the key is under the expected prefix for this pet
+    if (!imageKey.startsWith(`contact-images/${petId}/`)) {
+      return badRequest('INVALID_INPUT', 'Invalid imageKey — must belong to this pet')
     }
 
-    const allowedMimeTypes = ['image/jpeg', 'image/png']
-    if (!allowedMimeTypes.includes(mimeType)) {
-      return badRequest('INVALID_INPUT', 'Image must be JPEG or PNG format')
-    }
-
-    const imageBuffer = Buffer.from(imageBase64, 'base64')
-    const maxSize = 10 * 1024 * 1024 // 10MB
-    if (imageBuffer.length > maxSize) {
-      return badRequest('INVALID_INPUT', 'Image must be 10MB or less')
-    }
-
-    // Upload image to S3 under contact-images/{petId}/{timestamp}.{ext}
-    const ext = mimeType === 'image/png' ? 'png' : 'jpg'
-    const timestamp = Date.now()
-    const s3Key = `contact-images/${petId}/${timestamp}.${ext}`
     const bucketName = process.env.S3_BUCKET ?? process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images'
-
     const factory = new AWSClientFactory()
     const s3Client = factory.createS3Client()
 
-    await s3Client.send(
-      new PutObjectCommand({
-        Bucket: bucketName,
-        Key: s3Key,
-        Body: imageBuffer,
-        ContentType: mimeType,
-        Metadata: {
-          petId,
-          senderEmail,
-          purpose: 'contact-attachment',
-        },
-      })
-    )
-
-    // Generate pre-signed GET URL valid for 7 days
     const getCommand = new GetObjectCommand({
       Bucket: bucketName,
-      Key: s3Key,
+      Key: imageKey,
     })
     const sevenDaysInSeconds = 7 * 24 * 60 * 60
     imageUrl = await getSignedUrl(s3Client, getCommand, { expiresIn: sevenDaysInSeconds })

--- a/backend/src/handlers/emergency-tools-handler.ts
+++ b/backend/src/handlers/emergency-tools-handler.ts
@@ -16,6 +16,8 @@
  */
 
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
+import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { CareSnapshotService } from '../services/care-snapshot-service'
 import { EmergencyToolsService } from '../services/emergency-tools-service'
 import { FlyerGenerationService } from '../services/flyer-generation-service'
@@ -26,6 +28,7 @@ import { extractUserFromIdToken } from '../services/token-utils'
 import { PetRepository } from '../repositories/pet-repository'
 import { ClinicRepository } from '../repositories/clinic-repository'
 import { ImageRepository } from '../repositories/image-repository'
+import { AWSClientFactory } from '../infrastructure/aws-client-factory'
 import { ErrorHandler } from '../errors/index'
 
 import { NotificationService } from '../services/notification-service'
@@ -330,16 +333,17 @@ async function handlePhotoGuidance(
 
 /**
  * POST /pets/{petId}/contact — Send anonymous message to pet owner (Public)
- * Accepts senderName, senderEmail, message. Looks up owner email from pet record
- * and sends via NotificationService without exposing owner PII to sender.
- * Requirements: [FR-15]
+ * Accepts senderName, senderEmail, message, and optional imageBase64/mimeType.
+ * If an image is provided, uploads to S3 under contact-images/{petId}/{timestamp}.{ext},
+ * generates a 7-day pre-signed URL, and includes it in the notification.
+ * Requirements: [FR-12], [FR-15]
  */
 async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   const petId = event.pathParameters?.petId
   if (!petId) return badRequest('INVALID_INPUT', 'petId is required')
 
   const body = event.body ? JSON.parse(event.body) : {}
-  const { senderName, senderEmail, message } = body
+  const { senderName, senderEmail, message, imageBase64, mimeType } = body
 
   if (!senderName || !senderEmail || !message) {
     return badRequest('INVALID_INPUT', 'senderName, senderEmail, and message are required')
@@ -354,6 +358,62 @@ async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatew
     return badRequest('INVALID_INPUT', 'Message must be 1000 characters or less')
   }
 
+  // Validate image attachment if provided
+  let imageUrl: string | undefined
+  if (imageBase64) {
+    if (!mimeType) {
+      return badRequest('INVALID_INPUT', 'mimeType is required when imageBase64 is provided')
+    }
+
+    const allowedMimeTypes = ['image/jpeg', 'image/png']
+    if (!allowedMimeTypes.includes(mimeType)) {
+      return badRequest('INVALID_INPUT', 'Image must be JPEG or PNG format')
+    }
+
+    const imageBuffer = Buffer.from(imageBase64, 'base64')
+    const maxSize = 10 * 1024 * 1024 // 10MB
+    if (imageBuffer.length > maxSize) {
+      return badRequest('INVALID_INPUT', 'Image must be 10MB or less')
+    }
+
+    // Upload image to S3 under contact-images/{petId}/{timestamp}.{ext}
+    const ext = mimeType === 'image/png' ? 'png' : 'jpg'
+    const timestamp = Date.now()
+    const s3Key = `contact-images/${petId}/${timestamp}.${ext}`
+    const bucketName = process.env.S3_BUCKET ?? process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images'
+
+    const factory = new AWSClientFactory()
+    const s3Client = factory.createS3Client()
+
+    await s3Client.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: s3Key,
+        Body: imageBuffer,
+        ContentType: mimeType,
+        Metadata: {
+          petId,
+          senderEmail,
+          purpose: 'contact-attachment',
+        },
+      })
+    )
+
+    // Generate pre-signed GET URL valid for 7 days
+    const getCommand = new GetObjectCommand({
+      Bucket: bucketName,
+      Key: s3Key,
+    })
+    const sevenDaysInSeconds = 7 * 24 * 60 * 60
+    imageUrl = await getSignedUrl(s3Client, getCommand, { expiresIn: sevenDaysInSeconds })
+
+    // Replace Docker-internal hostnames with localhost for local dev
+    const localstackHost = process.env.LOCALSTACK_HOSTNAME
+    if (localstackHost && localstackHost !== 'localhost') {
+      imageUrl = imageUrl.replace(`http://${localstackHost}:`, 'http://localhost:')
+    }
+  }
+
   const pet = await petRepo.findById(petId)
   if (!pet) return respond(404, { error: { code: 'NOT_FOUND', message: 'Pet not found' } })
   if (!pet.ownerEmail) return badRequest('NO_OWNER', 'This pet does not have an owner to contact')
@@ -366,6 +426,9 @@ async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatew
     console.log(`  From: ${senderName} <${senderEmail}>`)
     console.log(`  Pet: ${pet.name}`)
     console.log(`  Message: ${message}`)
+    if (imageUrl) {
+      console.log(`  📷 Image: ${imageUrl}`)
+    }
   }
 
   await notificationService.sendContactMessage({
@@ -374,6 +437,7 @@ async function handleContactOwner(event: APIGatewayProxyEvent): Promise<APIGatew
     senderName,
     senderEmail,
     message,
+    imageUrl,
   })
 
   return respond(200, { success: true, message: 'Message sent to pet owner' })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -101,6 +101,7 @@ app.put('/pets/:petId/found', wrap(emergencyToolsHandler))
 app.get('/pets/:petId/flyer', wrap(emergencyToolsHandler))
 app.get('/pets/:petId/photo-guidance', wrap(emergencyToolsHandler))
 app.post('/pets/:petId/care-snapshot', wrap(emergencyToolsHandler))
+app.post('/pets/:petId/contact/upload-url', wrap(emergencyToolsHandler))
 app.post('/pets/:petId/contact', wrap(emergencyToolsHandler))
 app.get('/care-snapshots/:accessCode', wrap(emergencyToolsHandler))
 

--- a/backend/src/services/notification-service.ts
+++ b/backend/src/services/notification-service.ts
@@ -83,6 +83,8 @@ export interface ContactMessageInput {
   senderName: string
   senderEmail: string
   message: string
+  /** Optional pre-signed URL for an attached image (valid for 7 days) */
+  imageUrl?: string
 }
 
 export class NotificationService {
@@ -413,22 +415,36 @@ export class NotificationService {
   async sendContactMessage(
     input: ContactMessageInput
   ): Promise<NotificationResult> {
-    const { petName, ownerEmail, senderName, senderEmail, message } = input
+    const { petName, ownerEmail, senderName, senderEmail, message, imageUrl } = input
     const timestamp = new Date().toISOString()
 
     const subject = `PawPrint: Someone has a message about ${petName}`
-    const body = [
+    const bodyLines = [
       `You received a message through PawPrint about your pet ${petName}.`,
       '',
       `From: ${senderName} (${senderEmail})`,
       '',
       `Message:`,
       message,
+    ]
+
+    if (imageUrl) {
+      bodyLines.push(
+        '',
+        `📷 Attached Image:`,
+        imageUrl,
+        `(This link is valid for 7 days)`
+      )
+    }
+
+    bodyLines.push(
       '',
       `---`,
       `You can reply directly to ${senderEmail} to respond.`,
-      `This message was sent through the PawPrint platform to protect your privacy.`,
-    ].join('\n')
+      `This message was sent through the PawPrint platform to protect your privacy.`
+    )
+
+    const body = bodyLines.join('\n')
 
     try {
       const result = await this.sendEmail(ownerEmail, subject, body)

--- a/backend/tests/contact-image-attachment.unit.test.ts
+++ b/backend/tests/contact-image-attachment.unit.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Unit tests for POST /pets/{petId}/contact image attachment support
+ *
+ * Tests verify:
+ * - Text-only messages still work (backward compatibility)
+ * - Image attachment is uploaded to S3 under contact-images/{petId}/{timestamp}.{ext}
+ * - Pre-signed URL (7 days) is generated and included in notification
+ * - Validation rejects invalid mime types, oversized images, missing mimeType
+ * - Image is NOT added to pet profile (temporary attachment only)
+ *
+ * Validates: [FR-12], [FR-15]
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { APIGatewayProxyEvent } from 'aws-lambda'
+
+// ── Mock S3 ──────────────────────────────────────────────────────────────────
+
+const mockS3Send = vi.fn()
+const mockGetSignedUrl = vi.fn()
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn().mockImplementation(() => ({ send: mockS3Send })),
+  PutObjectCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'PutObject' })),
+  GetObjectCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'GetObject' })),
+}))
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args: any[]) => mockGetSignedUrl(...args),
+}))
+
+// ── Mock SNS ─────────────────────────────────────────────────────────────────
+
+const mockSnsSend = vi.fn()
+
+vi.mock('@aws-sdk/client-sns', () => ({
+  SNSClient: vi.fn().mockImplementation(() => ({ send: mockSnsSend })),
+  PublishCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'Publish' })),
+  CreateTopicCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'CreateTopic' })),
+  SubscribeCommand: vi.fn(),
+}))
+
+// ── Mock DynamoDB ────────────────────────────────────────────────────────────
+
+const mockDocSend = vi.fn()
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn().mockImplementation(() => ({})),
+}))
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn().mockReturnValue({ send: mockDocSend }),
+  },
+  GetCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'Get' })),
+  PutCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'Put' })),
+  QueryCommand: vi.fn().mockImplementation((input) => ({ ...input, _type: 'Query' })),
+  DeleteCommand: vi.fn(),
+}))
+
+// ── Mock infrastructure ──────────────────────────────────────────────────────
+
+vi.mock('../src/infrastructure/aws-client-factory', () => ({
+  AWSClientFactory: vi.fn().mockImplementation(() => ({
+    createDynamoDBClient: vi.fn().mockReturnValue({}),
+    createS3Client: vi.fn().mockReturnValue({ send: mockS3Send }),
+    createSNSClient: vi.fn().mockReturnValue({ send: mockSnsSend }),
+    createCognitoClient: vi.fn().mockReturnValue({}),
+  })),
+}))
+
+vi.mock('../src/infrastructure/environment-detector', () => ({
+  EnvironmentDetector: {
+    getInstance: vi.fn().mockReturnValue({
+      isLocal: vi.fn().mockReturnValue(true),
+      getServiceEndpoint: vi.fn().mockReturnValue('http://localhost:4566'),
+      getRegion: vi.fn().mockReturnValue('us-east-1'),
+      getConfig: vi.fn().mockReturnValue({ region: 'us-east-1' }),
+    }),
+  },
+}))
+
+// ── Mock Cognito ─────────────────────────────────────────────────────────────
+
+vi.mock('@aws-sdk/client-cognito-identity-provider', () => ({
+  CognitoIdentityProviderClient: vi.fn().mockImplementation(() => ({})),
+  AdminGetUserCommand: vi.fn(),
+  GetUserCommand: vi.fn(),
+}))
+
+// Import handler after mocks
+const { handler } = await import('../src/handlers/emergency-tools-handler')
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+  return {
+    httpMethod: 'POST',
+    path: '/pets/pet-123/contact',
+    resource: '/pets/{petId}/contact',
+    pathParameters: { petId: 'pet-123' },
+    headers: {},
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    multiValueHeaders: {},
+    stageVariable: null,
+    requestContext: {} as any,
+    isBase64Encoded: false,
+    body: null,
+    ...overrides,
+  }
+}
+
+const claimedPet = {
+  PK: 'PET#pet-123',
+  SK: 'METADATA',
+  petId: 'pet-123',
+  name: 'Buddy',
+  species: 'Dog',
+  breed: 'Labrador',
+  age: 4,
+  clinicId: 'clinic-1',
+  profileStatus: 'Active',
+  medicallyVerified: true,
+  verifyingVetId: 'vet-1',
+  verificationDate: '2024-01-01T00:00:00Z',
+  ownerId: 'owner-1',
+  ownerName: 'Jane',
+  ownerEmail: 'jane@example.com',
+  ownerPhone: '+1555000000',
+  isMissing: true,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  GSI2PK: 'SPECIES#Dog',
+  GSI2SK: 'BREED#Labrador#AGE#4',
+}
+
+// Small valid JPEG (1x1 pixel) as base64
+const TINY_JPEG_BASE64 = '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYI4Q/SFhSRyQ4VypTJDdEkoJWRVJFRmfH/9oADAMBAAIRAxEAPwC/RRRQAf/Z'
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /pets/{petId}/contact — Image Attachment [FR-12][FR-15]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.IS_LOCAL = 'true'
+
+    // DynamoDB: return claimed pet
+    mockDocSend.mockResolvedValue({ Item: claimedPet })
+
+    // SNS: succeed
+    mockSnsSend.mockResolvedValue({
+      TopicArn: 'arn:aws:sns:us-east-1:000000000000:paw-print-email-notifications',
+      MessageId: 'msg-001',
+    })
+
+    // S3 upload: succeed
+    mockS3Send.mockResolvedValue({})
+
+    // Pre-signed URL
+    mockGetSignedUrl.mockResolvedValue('http://localhost:4566/paw-print-profile-images/contact-images/pet-123/123456.jpg?X-Amz-Signature=abc')
+  })
+
+  describe('Backward compatibility — text-only messages', () => {
+    it('sends text-only message successfully without image', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Alice',
+          senderEmail: 'alice@example.com',
+          message: 'I think I found your dog!',
+        }),
+      })
+
+      const result = await handler(event)
+      const body = JSON.parse(result.body)
+
+      expect(result.statusCode).toBe(200)
+      expect(body.success).toBe(true)
+      // S3 should NOT be called for text-only messages
+      expect(mockS3Send).not.toHaveBeenCalled()
+      expect(mockGetSignedUrl).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Image upload to S3', () => {
+    it('uploads image to contact-images/{petId}/{timestamp}.{ext}', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Bob',
+          senderEmail: 'bob@example.com',
+          message: 'Found a dog matching your description',
+          imageBase64: TINY_JPEG_BASE64,
+          mimeType: 'image/jpeg',
+        }),
+      })
+
+      const result = await handler(event)
+      const body = JSON.parse(result.body)
+
+      expect(result.statusCode).toBe(200)
+      expect(body.success).toBe(true)
+
+      // Verify S3 PutObject was called
+      expect(mockS3Send).toHaveBeenCalled()
+      const putCall = mockS3Send.mock.calls[0][0]
+      expect(putCall.Key).toMatch(/^contact-images\/pet-123\/\d+\.jpg$/)
+      expect(putCall.ContentType).toBe('image/jpeg')
+      expect(putCall.Bucket).toBe(process.env.S3_BUCKET ?? process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images')
+    })
+
+    it('uses .png extension for PNG images', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Carol',
+          senderEmail: 'carol@example.com',
+          message: 'Spotted your cat',
+          imageBase64: TINY_JPEG_BASE64,  // content doesn't matter for mock
+          mimeType: 'image/png',
+        }),
+      })
+
+      await handler(event)
+
+      const putCall = mockS3Send.mock.calls[0][0]
+      expect(putCall.Key).toMatch(/^contact-images\/pet-123\/\d+\.png$/)
+      expect(putCall.ContentType).toBe('image/png')
+    })
+
+    it('generates a pre-signed URL with 7-day expiry', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Dave',
+          senderEmail: 'dave@example.com',
+          message: 'Here is a photo',
+          imageBase64: TINY_JPEG_BASE64,
+          mimeType: 'image/jpeg',
+        }),
+      })
+
+      await handler(event)
+
+      // getSignedUrl should be called with 7 days in seconds
+      expect(mockGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ _type: 'GetObject' }),
+        { expiresIn: 7 * 24 * 60 * 60 }
+      )
+    })
+  })
+
+  describe('Validation', () => {
+    it('rejects imageBase64 without mimeType', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Eve',
+          senderEmail: 'eve@example.com',
+          message: 'Here is an image',
+          imageBase64: TINY_JPEG_BASE64,
+          // mimeType missing
+        }),
+      })
+
+      const result = await handler(event)
+      const body = JSON.parse(result.body)
+
+      expect(result.statusCode).toBe(400)
+      expect(body.error.message).toContain('mimeType is required')
+    })
+
+    it('rejects unsupported mime types (e.g., image/gif)', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Frank',
+          senderEmail: 'frank@example.com',
+          message: 'GIF attachment',
+          imageBase64: TINY_JPEG_BASE64,
+          mimeType: 'image/gif',
+        }),
+      })
+
+      const result = await handler(event)
+      const body = JSON.parse(result.body)
+
+      expect(result.statusCode).toBe(400)
+      expect(body.error.message).toContain('JPEG or PNG')
+    })
+
+    it('rejects images larger than 10MB', async () => {
+      // Create a base64 string that decodes to > 10MB
+      // Base64 encoding ratio: 4 characters represent 3 bytes
+      // Need > 10MB = 10485760 bytes → need at least 13981014 base64 chars
+      const largeBase64 = 'A'.repeat(14_000_000)
+
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Grace',
+          senderEmail: 'grace@example.com',
+          message: 'Huge image',
+          imageBase64: largeBase64,
+          mimeType: 'image/jpeg',
+        }),
+      })
+
+      const result = await handler(event)
+      const body = JSON.parse(result.body)
+
+      expect(result.statusCode).toBe(400)
+      expect(body.error.message).toContain('10MB or less')
+    })
+
+    it('still validates required text fields with image present', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: '',
+          senderEmail: 'test@test.com',
+          message: 'Hi',
+          imageBase64: TINY_JPEG_BASE64,
+          mimeType: 'image/jpeg',
+        }),
+      })
+
+      const result = await handler(event)
+
+      expect(result.statusCode).toBe(400)
+    })
+  })
+
+  describe('Pre-signed URL in notification', () => {
+    it('includes image URL in the notification when image is provided', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Helen',
+          senderEmail: 'helen@example.com',
+          message: 'I found this dog near the park',
+          imageBase64: TINY_JPEG_BASE64,
+          mimeType: 'image/jpeg',
+        }),
+      })
+
+      await handler(event)
+
+      // SNS publish should include the image URL in the message body
+      // The message is sent via sendEmail → SNS publish
+      expect(mockSnsSend).toHaveBeenCalled()
+      const snsCall = mockSnsSend.mock.calls.find((call: any) => {
+        const msg = call[0]?.Message
+        if (msg) {
+          try {
+            const parsed = JSON.parse(msg)
+            return parsed.body?.includes('Attached Image')
+          } catch {
+            return false
+          }
+        }
+        return false
+      })
+      // The notification was sent (we already verified 200 success)
+      // The image URL is included in the message to the owner
+      expect(mockSnsSend).toHaveBeenCalled()
+    })
+
+    it('does NOT include image section in notification when no image provided', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Ivan',
+          senderEmail: 'ivan@example.com',
+          message: 'No image here',
+        }),
+      })
+
+      await handler(event)
+
+      // All SNS calls should NOT contain "Attached Image" in message body
+      for (const call of mockSnsSend.mock.calls) {
+        const msg = call[0]?.Message
+        if (msg) {
+          try {
+            const parsed = JSON.parse(msg)
+            if (parsed.body) {
+              expect(parsed.body).not.toContain('Attached Image')
+            }
+          } catch {
+            // non-JSON message (e.g. CreateTopic), skip
+          }
+        }
+      }
+    })
+  })
+
+  describe('Image is NOT added to pet profile', () => {
+    it('does not write to DynamoDB IMAGE# record for contact images', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: 'Jake',
+          senderEmail: 'jake@example.com',
+          message: 'Photo attached',
+          imageBase64: TINY_JPEG_BASE64,
+          mimeType: 'image/jpeg',
+        }),
+      })
+
+      await handler(event)
+
+      // DynamoDB should only be called for pet lookup (GetCommand), not PutCommand for IMAGE#
+      for (const call of mockDocSend.mock.calls) {
+        const item = call[0]?.Item
+        if (item && item.SK) {
+          expect(item.SK).not.toMatch(/^IMAGE#/)
+        }
+      }
+    })
+  })
+})

--- a/backend/tests/contact-image-attachment.unit.test.ts
+++ b/backend/tests/contact-image-attachment.unit.test.ts
@@ -1,11 +1,11 @@
 /**
- * Unit tests for POST /pets/{petId}/contact image attachment support
+ * Unit tests for contact image attachment via pre-signed S3 upload pattern
  *
  * Tests verify:
+ * - POST /pets/{petId}/contact/upload-url generates a pre-signed PUT URL
+ * - POST /pets/{petId}/contact accepts imageKey and generates GET pre-signed URL
  * - Text-only messages still work (backward compatibility)
- * - Image attachment is uploaded to S3 under contact-images/{petId}/{timestamp}.{ext}
- * - Pre-signed URL (7 days) is generated and included in notification
- * - Validation rejects invalid mime types, oversized images, missing mimeType
+ * - Validation rejects invalid mime types, invalid imageKey prefixes
  * - Image is NOT added to pet profile (temporary attachment only)
  *
  * Validates: [FR-12], [FR-15]
@@ -135,30 +135,95 @@ const claimedPet = {
   GSI2SK: 'BREED#Labrador#AGE#4',
 }
 
-// Small valid JPEG (1x1 pixel) as base64
-const TINY_JPEG_BASE64 = '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYI4Q/SFhSRyQ4VypTJDdEkoJWRVJFRmfH/9oADAMBAAIRAxEAPwC/RRRQAf/Z'
-
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe('POST /pets/{petId}/contact — Image Attachment [FR-12][FR-15]', () => {
+describe('POST /pets/{petId}/contact/upload-url — Pre-signed Upload URL [FR-12][FR-15]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     process.env.IS_LOCAL = 'true'
+    mockGetSignedUrl.mockResolvedValue('http://localhost:4566/paw-print-profile-images/contact-images/pet-123/123456.jpg?X-Amz-Signature=abc')
+  })
 
-    // DynamoDB: return claimed pet
+  it('returns a pre-signed PUT URL and imageKey for JPEG', async () => {
+    const event = makeEvent({
+      path: '/pets/pet-123/contact/upload-url',
+      resource: '/pets/{petId}/contact/upload-url',
+      body: JSON.stringify({ mimeType: 'image/jpeg' }),
+    })
+
+    const result = await handler(event)
+    const body = JSON.parse(result.body)
+
+    expect(result.statusCode).toBe(200)
+    expect(body.uploadUrl).toContain('localhost')
+    expect(body.imageKey).toMatch(/^contact-images\/pet-123\/\d+\.jpg$/)
+  })
+
+  it('returns .png extension for PNG images', async () => {
+    const event = makeEvent({
+      path: '/pets/pet-123/contact/upload-url',
+      resource: '/pets/{petId}/contact/upload-url',
+      body: JSON.stringify({ mimeType: 'image/png' }),
+    })
+
+    const result = await handler(event)
+    const body = JSON.parse(result.body)
+
+    expect(result.statusCode).toBe(200)
+    expect(body.imageKey).toMatch(/^contact-images\/pet-123\/\d+\.png$/)
+  })
+
+  it('rejects missing mimeType', async () => {
+    const event = makeEvent({
+      path: '/pets/pet-123/contact/upload-url',
+      resource: '/pets/{petId}/contact/upload-url',
+      body: JSON.stringify({}),
+    })
+
+    const result = await handler(event)
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body).error.message).toContain('mimeType is required')
+  })
+
+  it('rejects unsupported mime types (e.g., image/gif)', async () => {
+    const event = makeEvent({
+      path: '/pets/pet-123/contact/upload-url',
+      resource: '/pets/{petId}/contact/upload-url',
+      body: JSON.stringify({ mimeType: 'image/gif' }),
+    })
+
+    const result = await handler(event)
+    expect(result.statusCode).toBe(400)
+    expect(JSON.parse(result.body).error.message).toContain('JPEG or PNG')
+  })
+
+  it('generates pre-signed URL with 15 minute expiry', async () => {
+    const event = makeEvent({
+      path: '/pets/pet-123/contact/upload-url',
+      resource: '/pets/{petId}/contact/upload-url',
+      body: JSON.stringify({ mimeType: 'image/jpeg' }),
+    })
+
+    await handler(event)
+
+    expect(mockGetSignedUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ _type: 'PutObject' }),
+      { expiresIn: 900 }
+    )
+  })
+})
+
+describe('POST /pets/{petId}/contact — Contact with imageKey [FR-12][FR-15]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.IS_LOCAL = 'true'
     mockDocSend.mockResolvedValue({ Item: claimedPet })
-
-    // SNS: succeed
     mockSnsSend.mockResolvedValue({
       TopicArn: 'arn:aws:sns:us-east-1:000000000000:paw-print-email-notifications',
       MessageId: 'msg-001',
     })
-
-    // S3 upload: succeed
-    mockS3Send.mockResolvedValue({})
-
-    // Pre-signed URL
-    mockGetSignedUrl.mockResolvedValue('http://localhost:4566/paw-print-profile-images/contact-images/pet-123/123456.jpg?X-Amz-Signature=abc')
+    mockGetSignedUrl.mockResolvedValue('http://localhost:4566/paw-print-profile-images/contact-images/pet-123/123456.jpg?X-Amz-Signature=xyz')
   })
 
   describe('Backward compatibility — text-only messages', () => {
@@ -176,21 +241,19 @@ describe('POST /pets/{petId}/contact — Image Attachment [FR-12][FR-15]', () =>
 
       expect(result.statusCode).toBe(200)
       expect(body.success).toBe(true)
-      // S3 should NOT be called for text-only messages
-      expect(mockS3Send).not.toHaveBeenCalled()
+      // getSignedUrl should NOT be called for text-only messages
       expect(mockGetSignedUrl).not.toHaveBeenCalled()
     })
   })
 
-  describe('Image upload to S3', () => {
-    it('uploads image to contact-images/{petId}/{timestamp}.{ext}', async () => {
+  describe('imageKey-based image reference', () => {
+    it('accepts imageKey and generates a 7-day GET pre-signed URL', async () => {
       const event = makeEvent({
         body: JSON.stringify({
           senderName: 'Bob',
           senderEmail: 'bob@example.com',
           message: 'Found a dog matching your description',
-          imageBase64: TINY_JPEG_BASE64,
-          mimeType: 'image/jpeg',
+          imageKey: 'contact-images/pet-123/1700000000.jpg',
         }),
       })
 
@@ -200,190 +263,42 @@ describe('POST /pets/{petId}/contact — Image Attachment [FR-12][FR-15]', () =>
       expect(result.statusCode).toBe(200)
       expect(body.success).toBe(true)
 
-      // Verify S3 PutObject was called
-      expect(mockS3Send).toHaveBeenCalled()
-      const putCall = mockS3Send.mock.calls[0][0]
-      expect(putCall.Key).toMatch(/^contact-images\/pet-123\/\d+\.jpg$/)
-      expect(putCall.ContentType).toBe('image/jpeg')
-      expect(putCall.Bucket).toBe(process.env.S3_BUCKET ?? process.env.PET_IMAGES_BUCKET ?? 'paw-print-profile-images')
-    })
-
-    it('uses .png extension for PNG images', async () => {
-      const event = makeEvent({
-        body: JSON.stringify({
-          senderName: 'Carol',
-          senderEmail: 'carol@example.com',
-          message: 'Spotted your cat',
-          imageBase64: TINY_JPEG_BASE64,  // content doesn't matter for mock
-          mimeType: 'image/png',
-        }),
-      })
-
-      await handler(event)
-
-      const putCall = mockS3Send.mock.calls[0][0]
-      expect(putCall.Key).toMatch(/^contact-images\/pet-123\/\d+\.png$/)
-      expect(putCall.ContentType).toBe('image/png')
-    })
-
-    it('generates a pre-signed URL with 7-day expiry', async () => {
-      const event = makeEvent({
-        body: JSON.stringify({
-          senderName: 'Dave',
-          senderEmail: 'dave@example.com',
-          message: 'Here is a photo',
-          imageBase64: TINY_JPEG_BASE64,
-          mimeType: 'image/jpeg',
-        }),
-      })
-
-      await handler(event)
-
-      // getSignedUrl should be called with 7 days in seconds
+      // Should generate a GET pre-signed URL with 7-day expiry
       expect(mockGetSignedUrl).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ _type: 'GetObject' }),
+        expect.objectContaining({ _type: 'GetObject', Key: 'contact-images/pet-123/1700000000.jpg' }),
         { expiresIn: 7 * 24 * 60 * 60 }
       )
     })
-  })
 
-  describe('Validation', () => {
-    it('rejects imageBase64 without mimeType', async () => {
+    it('rejects imageKey that does not match the petId prefix', async () => {
       const event = makeEvent({
         body: JSON.stringify({
           senderName: 'Eve',
           senderEmail: 'eve@example.com',
-          message: 'Here is an image',
-          imageBase64: TINY_JPEG_BASE64,
-          // mimeType missing
+          message: 'Spoofed image key',
+          imageKey: 'contact-images/pet-999/1700000000.jpg',
         }),
       })
 
       const result = await handler(event)
-      const body = JSON.parse(result.body)
-
       expect(result.statusCode).toBe(400)
-      expect(body.error.message).toContain('mimeType is required')
+      expect(JSON.parse(result.body).error.message).toContain('must belong to this pet')
     })
 
-    it('rejects unsupported mime types (e.g., image/gif)', async () => {
+    it('rejects imageKey with path traversal attempt', async () => {
       const event = makeEvent({
         body: JSON.stringify({
-          senderName: 'Frank',
-          senderEmail: 'frank@example.com',
-          message: 'GIF attachment',
-          imageBase64: TINY_JPEG_BASE64,
-          mimeType: 'image/gif',
+          senderName: 'Mallory',
+          senderEmail: 'mallory@example.com',
+          message: 'Path traversal',
+          imageKey: 'pets/pet-123/private-image.jpg',
         }),
       })
 
       const result = await handler(event)
-      const body = JSON.parse(result.body)
-
       expect(result.statusCode).toBe(400)
-      expect(body.error.message).toContain('JPEG or PNG')
-    })
-
-    it('rejects images larger than 10MB', async () => {
-      // Create a base64 string that decodes to > 10MB
-      // Base64 encoding ratio: 4 characters represent 3 bytes
-      // Need > 10MB = 10485760 bytes → need at least 13981014 base64 chars
-      const largeBase64 = 'A'.repeat(14_000_000)
-
-      const event = makeEvent({
-        body: JSON.stringify({
-          senderName: 'Grace',
-          senderEmail: 'grace@example.com',
-          message: 'Huge image',
-          imageBase64: largeBase64,
-          mimeType: 'image/jpeg',
-        }),
-      })
-
-      const result = await handler(event)
-      const body = JSON.parse(result.body)
-
-      expect(result.statusCode).toBe(400)
-      expect(body.error.message).toContain('10MB or less')
-    })
-
-    it('still validates required text fields with image present', async () => {
-      const event = makeEvent({
-        body: JSON.stringify({
-          senderName: '',
-          senderEmail: 'test@test.com',
-          message: 'Hi',
-          imageBase64: TINY_JPEG_BASE64,
-          mimeType: 'image/jpeg',
-        }),
-      })
-
-      const result = await handler(event)
-
-      expect(result.statusCode).toBe(400)
-    })
-  })
-
-  describe('Pre-signed URL in notification', () => {
-    it('includes image URL in the notification when image is provided', async () => {
-      const event = makeEvent({
-        body: JSON.stringify({
-          senderName: 'Helen',
-          senderEmail: 'helen@example.com',
-          message: 'I found this dog near the park',
-          imageBase64: TINY_JPEG_BASE64,
-          mimeType: 'image/jpeg',
-        }),
-      })
-
-      await handler(event)
-
-      // SNS publish should include the image URL in the message body
-      // The message is sent via sendEmail → SNS publish
-      expect(mockSnsSend).toHaveBeenCalled()
-      const snsCall = mockSnsSend.mock.calls.find((call: any) => {
-        const msg = call[0]?.Message
-        if (msg) {
-          try {
-            const parsed = JSON.parse(msg)
-            return parsed.body?.includes('Attached Image')
-          } catch {
-            return false
-          }
-        }
-        return false
-      })
-      // The notification was sent (we already verified 200 success)
-      // The image URL is included in the message to the owner
-      expect(mockSnsSend).toHaveBeenCalled()
-    })
-
-    it('does NOT include image section in notification when no image provided', async () => {
-      const event = makeEvent({
-        body: JSON.stringify({
-          senderName: 'Ivan',
-          senderEmail: 'ivan@example.com',
-          message: 'No image here',
-        }),
-      })
-
-      await handler(event)
-
-      // All SNS calls should NOT contain "Attached Image" in message body
-      for (const call of mockSnsSend.mock.calls) {
-        const msg = call[0]?.Message
-        if (msg) {
-          try {
-            const parsed = JSON.parse(msg)
-            if (parsed.body) {
-              expect(parsed.body).not.toContain('Attached Image')
-            }
-          } catch {
-            // non-JSON message (e.g. CreateTopic), skip
-          }
-        }
-      }
+      expect(JSON.parse(result.body).error.message).toContain('must belong to this pet')
     })
   })
 
@@ -394,20 +309,34 @@ describe('POST /pets/{petId}/contact — Image Attachment [FR-12][FR-15]', () =>
           senderName: 'Jake',
           senderEmail: 'jake@example.com',
           message: 'Photo attached',
-          imageBase64: TINY_JPEG_BASE64,
-          mimeType: 'image/jpeg',
+          imageKey: 'contact-images/pet-123/1700000000.jpg',
         }),
       })
 
       await handler(event)
 
-      // DynamoDB should only be called for pet lookup (GetCommand), not PutCommand for IMAGE#
       for (const call of mockDocSend.mock.calls) {
         const item = call[0]?.Item
         if (item && item.SK) {
           expect(item.SK).not.toMatch(/^IMAGE#/)
         }
       }
+    })
+  })
+
+  describe('Required field validation', () => {
+    it('still validates required text fields', async () => {
+      const event = makeEvent({
+        body: JSON.stringify({
+          senderName: '',
+          senderEmail: 'test@test.com',
+          message: 'Hi',
+          imageKey: 'contact-images/pet-123/1700000000.jpg',
+        }),
+      })
+
+      const result = await handler(event)
+      expect(result.statusCode).toBe(400)
     })
   })
 })

--- a/frontend/src/pages/public/ContactPetOwner.tsx
+++ b/frontend/src/pages/public/ContactPetOwner.tsx
@@ -4,13 +4,19 @@
  * No authentication required. Allows public users to send a message
  * to a pet owner without seeing their contact information.
  * Messages are sent through the platform to protect owner privacy.
+ * Optionally supports attaching a photo (e.g., of a found pet) as base64.
  *
- * Validates: [FR-11], [FR-15], [NFR-SEC-03]
+ * Validates: [FR-11], [FR-12], [FR-15]
  */
 
-import { useState } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { Upload, AlertTriangle, X } from 'lucide-react'
 import { api } from '../../api/client'
+
+const ACCEPTED_TYPES = ['image/jpeg', 'image/png']
+const MAX_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB
+const ACCEPTED_EXTENSIONS = '.jpeg,.jpg,.png'
 
 export function ContactPetOwner() {
   const { petId } = useParams<{ petId: string }>()
@@ -20,9 +26,100 @@ export function ContactPetOwner() {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Image attachment state
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
   function updateField(field: string, value: string) {
     setForm((prev) => ({ ...prev, [field]: value }))
   }
+
+  // ── Image Validation ─────────────────────────────────────────────────────
+
+  function validateFile(file: File): string | null {
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      return `Unsupported format: ${file.type.split('/')[1]?.toUpperCase() || 'unknown'}. Please use JPEG or PNG.`
+    }
+    if (file.size > MAX_SIZE_BYTES) {
+      return `File too large: ${(file.size / 1024 / 1024).toFixed(1)} MB. Maximum size is 10 MB.`
+    }
+    return null
+  }
+
+  // ── File Selection ───────────────────────────────────────────────────────
+
+  function processFile(file: File) {
+    const validationError = validateFile(file)
+    if (validationError) {
+      setImageError(validationError)
+      setSelectedFile(null)
+      setImagePreview(null)
+      return
+    }
+
+    setImageError(null)
+    setSelectedFile(file)
+
+    const reader = new FileReader()
+    reader.onload = (ev) => setImagePreview(ev.target?.result as string)
+    reader.readAsDataURL(file)
+  }
+
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (file) processFile(file)
+  }
+
+  function handleRemoveImage() {
+    setSelectedFile(null)
+    setImagePreview(null)
+    setImageError(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  // ── Drag and Drop ────────────────────────────────────────────────────────
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setDragOver(false)
+
+    const file = e.dataTransfer.files?.[0]
+    if (file) processFile(file)
+  }, [])
+
+  // ── Convert File to Base64 ───────────────────────────────────────────────
+
+  function fileToBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const result = reader.result as string
+        // Strip the data URL prefix to get raw base64
+        const base64 = result.split(',')[1]
+        resolve(base64)
+      }
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+  }
+
+  // ── Submit ───────────────────────────────────────────────────────────────
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -30,11 +127,22 @@ export function ContactPetOwner() {
     setError(null)
 
     try {
-      await api.post(`/pets/${petId}/contact`, {
+      const payload: Record<string, unknown> = {
         senderName: form.senderName,
         senderEmail: form.senderEmail,
         message: form.message,
-      })
+      }
+
+      // Attach image as base64 if selected
+      if (selectedFile && imagePreview) {
+        payload.image = {
+          data: await fileToBase64(selectedFile),
+          mimeType: selectedFile.type,
+          fileName: selectedFile.name,
+        }
+      }
+
+      await api.post(`/pets/${petId}/contact`, payload)
       setSubmitted(true)
     } catch (err: any) {
       if (err?.error?.message) {
@@ -46,6 +154,8 @@ export function ContactPetOwner() {
       setSubmitting(false)
     }
   }
+
+  // ── Success State ────────────────────────────────────────────────────────
 
   if (submitted) {
     return (
@@ -71,7 +181,7 @@ export function ContactPetOwner() {
           <button
             type="button"
             className="btn-secondary"
-            onClick={() => { setSubmitted(false); setForm({ senderName: '', senderEmail: '', message: '' }) }}
+            onClick={() => { setSubmitted(false); setForm({ senderName: '', senderEmail: '', message: '' }); handleRemoveImage() }}
           >
             Send Another Message
           </button>
@@ -79,6 +189,8 @@ export function ContactPetOwner() {
       </div>
     )
   }
+
+  // ── Form State ───────────────────────────────────────────────────────────
 
   return (
     <div>
@@ -132,6 +244,109 @@ export function ContactPetOwner() {
             }}
           />
         </div>
+
+        {/* Image attachment section [FR-12], [FR-15] */}
+        <div style={{ marginBottom: '15px' }}>
+          <p style={{ fontSize: '0.9rem', color: '#555', marginBottom: '8px', fontWeight: 500 }}>
+            Attach a photo (optional)
+          </p>
+          <p style={{ fontSize: '0.8rem', color: '#888', marginBottom: '10px' }}>
+            If you spotted the pet, attaching a photo can help the owner confirm identity.
+          </p>
+
+          {/* Drag-and-drop zone */}
+          <div
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current?.click()}
+            role="button"
+            tabIndex={0}
+            aria-label="Drop zone for photo attachment"
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') fileInputRef.current?.click() }}
+            style={{
+              border: `2px dashed ${dragOver ? '#667eea' : imageError ? '#dc3545' : '#ccc'}`,
+              borderRadius: '8px',
+              padding: '20px 16px',
+              textAlign: 'center',
+              cursor: 'pointer',
+              background: dragOver ? '#f0f4ff' : '#fafafa',
+              transition: 'all 0.2s ease',
+            }}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_EXTENSIONS}
+              onChange={handleFileSelect}
+              style={{ display: 'none' }}
+              aria-label="Select photo to attach"
+            />
+            {!selectedFile ? (
+              <div>
+                <p style={{ fontSize: '0.95rem', color: '#666', marginBottom: '4px' }}>
+                  <Upload size={18} style={{ verticalAlign: 'middle', marginRight: '6px' }} />
+                  Drag &amp; drop a photo here, or click to browse
+                </p>
+                <p style={{ fontSize: '0.75rem', color: '#999' }}>
+                  JPEG or PNG · Max 10 MB
+                </p>
+              </div>
+            ) : (
+              <p style={{ color: '#667eea', fontWeight: 600, fontSize: '0.9rem' }}>
+                ✓ {selectedFile.name} — click to change
+              </p>
+            )}
+          </div>
+
+          {/* Image error */}
+          {imageError && (
+            <p style={{ color: '#dc3545', marginTop: '8px', fontSize: '0.85rem' }}>
+              <AlertTriangle size={14} style={{ verticalAlign: 'middle', marginRight: '4px' }} />{imageError}
+            </p>
+          )}
+
+          {/* Image preview with remove button */}
+          {imagePreview && selectedFile && (
+            <div style={{ marginTop: '12px', display: 'flex', alignItems: 'flex-start', gap: '12px' }}>
+              <div style={{ position: 'relative', display: 'inline-block' }}>
+                <img
+                  src={imagePreview}
+                  alt="Attached photo preview"
+                  style={{ maxWidth: '200px', maxHeight: '150px', borderRadius: '6px', border: '1px solid #ddd' }}
+                />
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); handleRemoveImage() }}
+                  aria-label="Remove attached photo"
+                  style={{
+                    position: 'absolute',
+                    top: '-8px',
+                    right: '-8px',
+                    background: '#dc3545',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: '50%',
+                    width: '24px',
+                    height: '24px',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    padding: 0,
+                  }}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+              <div style={{ fontSize: '0.8rem', color: '#666' }}>
+                <p style={{ marginBottom: '2px' }}><strong>{selectedFile.name}</strong></p>
+                <p>{(selectedFile.size / 1024 / 1024).toFixed(2)} MB · {selectedFile.type.split('/')[1]?.toUpperCase()}</p>
+              </div>
+            </div>
+          )}
+        </div>
+
         <div style={{ display: 'flex', gap: '10px' }}>
           <button type="submit" disabled={submitting}>
             {submitting ? 'Sending...' : 'Send Message'}

--- a/frontend/src/pages/public/ContactPetOwner.tsx
+++ b/frontend/src/pages/public/ContactPetOwner.tsx
@@ -4,7 +4,8 @@
  * No authentication required. Allows public users to send a message
  * to a pet owner without seeing their contact information.
  * Messages are sent through the platform to protect owner privacy.
- * Optionally supports attaching a photo (e.g., of a found pet) as base64.
+ * Optionally supports attaching a photo via direct S3 upload (pre-signed URL).
+ * This bypasses the API Gateway payload limit by uploading directly to S3.
  *
  * Validates: [FR-11], [FR-12], [FR-15]
  */
@@ -103,20 +104,23 @@ export function ContactPetOwner() {
     if (file) processFile(file)
   }, [])
 
-  // ── Convert File to Base64 ───────────────────────────────────────────────
+  // ── Upload to S3 via pre-signed URL ───────────────────────────────────────
 
-  function fileToBase64(file: File): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => {
-        const result = reader.result as string
-        // Strip the data URL prefix to get raw base64
-        const base64 = result.split(',')[1]
-        resolve(base64)
-      }
-      reader.onerror = reject
-      reader.readAsDataURL(file)
+  async function uploadToS3(file: File): Promise<string> {
+    // 1. Get pre-signed PUT URL from backend
+    const { uploadUrl, imageKey } = await api.post<{ uploadUrl: string; imageKey: string }>(
+      `/pets/${petId}/contact/upload-url`,
+      { mimeType: file.type }
+    )
+
+    // 2. Upload file directly to S3
+    await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': file.type },
+      body: file,
     })
+
+    return imageKey
   }
 
   // ── Submit ───────────────────────────────────────────────────────────────
@@ -133,13 +137,9 @@ export function ContactPetOwner() {
         message: form.message,
       }
 
-      // Attach image as base64 if selected
-      if (selectedFile && imagePreview) {
-        payload.image = {
-          data: await fileToBase64(selectedFile),
-          mimeType: selectedFile.type,
-          fileName: selectedFile.name,
-        }
+      // Upload image directly to S3 if selected, then pass the key
+      if (selectedFile) {
+        payload.imageKey = await uploadToS3(selectedFile)
       }
 
       await api.post(`/pets/${petId}/contact`, payload)

--- a/template.yaml
+++ b/template.yaml
@@ -212,6 +212,10 @@ Resources:
             Prefix: temp/
             Status: Enabled
             ExpirationInDays: 1
+          - Id: DeleteContactImages
+            Prefix: contact-images/
+            Status: Enabled
+            ExpirationInDays: 30
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Cognito Auto-Confirm Lambda Trigger (must be before UserPool)

--- a/template.yaml
+++ b/template.yaml
@@ -610,6 +610,14 @@ Resources:
             Method: POST
             Auth:
               Authorizer: NONE
+        ContactUploadUrl:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PawPrintApi
+            Path: /pets/{petId}/contact/upload-url
+            Method: POST
+            Auth:
+              Authorizer: NONE
         GetPhotoGuidance:
           Type: Api
           Properties:


### PR DESCRIPTION
**Description**

Resolves #134.

This pull request adds support for attaching an image when contacting a pet owner through the public "Contact Owner" feature. It introduces a secure, two-step process that allows users to upload an image directly to S3 using a pre-signed URL, then references that image in their message. The backend validates the image type and access, generates pre-signed URLs for upload and download, and ensures images are not permanently stored as part of the pet's profile. Comprehensive unit tests are included to verify the new functionality and maintain backward compatibility.

**New Feature: Contact Owner Image Attachment**

* Added a public endpoint `POST /pets/{petId}/contact/upload-url` that returns a pre-signed S3 PUT URL for uploading a JPEG or PNG image, enabling users to attach a photo when contacting a pet owner. The endpoint validates the MIME type and restricts uploads to the correct S3 prefix for the pet. 
* Updated the `POST /pets/{petId}/contact` endpoint to accept an optional `imageKey`, generate a 7-day pre-signed GET URL for the image, and include this URL in the notification sent to the owner. The endpoint validates that the imageKey matches the pet's prefix and does not allow path traversal.

**Backend and Notification Enhancements**

* Modified the `NotificationService` to accept an optional `imageUrl` and include it in the email body sent to the pet owner, with clear indication of the attachment and expiry.
* Ensured that contact images are not saved to the pet's profile in DynamoDB, maintaining privacy and data hygiene.

**Validation and Testing**

* Added comprehensive unit tests to cover the new upload URL endpoint, imageKey validation, backward compatibility for text-only messages, and to confirm that images are not added to the pet profile.

**Frontend Integration**

* Updated the frontend `ContactPetOwner` page to support optional image attachment via direct S3 upload, enforcing file type and size restrictions.

**Infrastructure**

- SAM template: new ContactUploadUrl API event on the EmergencyTools function (public, no auth)
- S3 bucket: DeleteContactImages lifecycle rule (30-day expiry on contact-images/ prefix)

**Design decisions**

- Pre-signed upload pattern instead of base64-through-API-Gateway: eliminates the 10MB payload limit, reduces Lambda execution time, and keeps JSON payloads small
- imageKey prefix validation: backend verifies the key starts with contact-images/{petId}/ to prevent cross-pet access or path traversal
- Temporary storage: images auto-expire after 30 days (lifecycle rule) and are never added to the pet's profile — they're communication attachments only

**What was tested**

- 11 unit tests covering upload URL generation, imageKey validation, prefix security, backward compatibility (text-only messages), and verification that images aren't added to pet profiles
- TypeScript compilation clean (backend + frontend)
- SAM template validates with sam validate --lint

Validates [FR-12] (Pet Identification Assistance) and [FR-15] (Owner Privacy Protection).


